### PR TITLE
[#7]Enhancement: 키체인 CRUD 구현

### DIFF
--- a/Falling/Sources/DataLayer/Network/BaseTargetType.swift
+++ b/Falling/Sources/DataLayer/Network/BaseTargetType.swift
@@ -11,16 +11,14 @@ import Moya
 protocol BaseTargetType: TargetType { }
 
 extension BaseTargetType {
-
-  // Protocol Default Implementation
   var baseURL: URL {
     return URL(string: "http://tht-talk.store/")!
   }
 
   var headers: [String: String]? {
-    if AppData.accessToken.isEmpty == false {
+    if let accessToken = Keychain.shared.get("accessToken") {
       return [
-        "Authorization": "Bearer \(AppData.accessToken)",
+        "Authorization": "Bearer \(accessToken)",
         "Content-Type": "application/json",
       ]
     } else {

--- a/Falling/Sources/Foundation/AppData.swift
+++ b/Falling/Sources/Foundation/AppData.swift
@@ -9,12 +9,8 @@ import Foundation
 
 struct AppData {
   private enum Key: String {
-    case access_token
     case enable_auto_login
   }
-
-  @DataStorage(key: Key.access_token.rawValue, defaultValue: "")
-  static var accessToken: String
 
   @DataStorage(key: Key.enable_auto_login.rawValue, defaultValue: false)
   static var isEnableAutoLogin: Bool

--- a/Falling/Sources/Foundation/Keychain.swift
+++ b/Falling/Sources/Foundation/Keychain.swift
@@ -1,0 +1,110 @@
+//
+//  Keychain.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/08/02.
+//
+
+import Security
+import Foundation
+
+final class Keychain {
+  private let lock: NSLock = NSLock() // 멀티 스레드 환경에서 객체의 멤버에 동시 접근 방지
+  private var lastResultCode: OSStatus = noErr
+  
+  static let shared = Keychain()
+  
+  private init() { }
+  
+  @discardableResult
+  func set(_ value: String, forKey key: String) -> Bool {
+    if let value = value.data(using: String.Encoding.utf8) {
+      return set(value, forKey: key)
+    }
+    
+    return false
+  }
+  
+  @discardableResult
+  func set(_ value: Data, forKey key: String) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    let keyChainQuery: NSDictionary = [
+      kSecClass : kSecClassGenericPassword,
+      kSecAttrAccount: key,
+      kSecValueData: value
+    ]
+    
+    deleteNolock(key)
+    lastResultCode = SecItemAdd(keyChainQuery, nil)
+    
+    return lastResultCode == noErr
+  }
+  
+  func get(_ key: String) -> String? {
+    if let data = getData(key) {
+      if let currentString = String(data: data, encoding: .utf8) {
+        return currentString
+      }
+      
+      lastResultCode = -67853 // errSecInvalidEncoding
+    }
+
+    return nil
+  }
+  
+  func getData(_ key: String) -> Data? {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    let query: NSDictionary = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrAccount: key,
+      kSecReturnData: kCFBooleanTrue as Any,
+      kSecMatchLimit: kSecMatchLimitOne
+    ]
+    
+    var result: AnyObject?
+    
+    lastResultCode = withUnsafeMutablePointer(to: &result) {
+      SecItemCopyMatching(query as CFDictionary,
+                          UnsafeMutablePointer($0))
+    }
+    
+    if lastResultCode == noErr { return result as? Data }
+    return nil
+  }
+  
+  @discardableResult
+  func delete(_ key: String) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    return deleteNolock(key)
+  }
+  
+  @discardableResult
+  func deleteNolock(_ key: String) -> Bool {
+    let keyChainQuery: NSDictionary = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrAccount: key
+    ]
+    
+    lastResultCode = SecItemDelete(keyChainQuery)
+    return lastResultCode == noErr
+  }
+  
+  @discardableResult
+  func clear() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    
+    let keyChainQuery: NSDictionary = [
+      kSecClass: kSecClassGenericPassword,
+    ]
+    
+    lastResultCode = SecItemDelete(keyChainQuery)
+    return lastResultCode == noErr
+  }
+}

--- a/FallingTests/KeychainTest.swift
+++ b/FallingTests/KeychainTest.swift
@@ -1,0 +1,230 @@
+//
+//  KeychainTest.swift
+//  FallingTests
+//
+//  Created by SeungMin on 2023/08/02.
+//
+
+import XCTest
+@testable import Falling
+
+class KeychainTest: XCTestCase {
+  var obj: Keychain!
+  
+  override func setUp() {
+    super.setUp()
+    
+    obj = Keychain.shared
+    obj.clear()
+  }
+  
+  // MARK: - Set
+  func testSet() {
+    XCTAssertTrue(obj.set("Hello", forKey: "key 1"))
+    XCTAssertEqual("Hello", obj.get("key 1")!)
+  }
+  
+  // MARK: - Get
+  func testGet_returnNilWhenValueNotSet() {
+    XCTAssert(obj.get("key 1") == nil)
+  }
+  
+  // MARK: - Delete
+  func testDelete() {
+    obj.set("Hello", forKey: "key 1")
+    obj.delete("key 1")
+    
+    XCTAssert(obj.get("key 1") == nil)
+  }
+  
+  func testDelete_deleteOnSingleKey() {
+    obj.set("Hello", forKey: "key 1")
+    obj.set("Hello!!", forKey: "key 2")
+    
+    obj.delete("key 1")
+    
+    XCTAssertEqual("Hello!!", obj.get("key 2")!)
+  }
+  
+  // MARK: - Clear
+  func testClear() {
+    obj.set("Hello", forKey: "key 1")
+    obj.set("Hello!!", forKey: "key 2")
+    
+    obj.clear()
+    
+    XCTAssert(obj.get("key 1") == nil)
+    XCTAssert(obj.get("key 2") == nil)
+  }
+  
+  func testConcurrencyDoesntCrash() {
+    let expectation = self.expectation(description: "Wait for write loop")
+    let expectation2 = self.expectation(description: "Wait for write loop")
+    
+    let dataToWrite = "{ asdf ñlk BNALSKDJFÑLAKSJDFÑLKJ ZÑCLXKJ ÑALSKDFJÑLKASJDFÑLKJASDÑFLKJAÑSDLKFJÑLKJ}"
+    obj.set(dataToWrite, forKey: "test-key")
+    
+    var writes = 0
+    
+    let readQueue = DispatchQueue(label: "ReadQueue", attributes: [])
+    readQueue.async {
+      for _ in 0..<400 {
+        let _: String? = synchronize( { completion in
+          let result: String? = self.obj.get("test-key")
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: nil)
+      }
+    }
+    let readQueue2 = DispatchQueue(label: "ReadQueue2", attributes: [])
+    readQueue2.async {
+      for _ in 0..<400 {
+        let _: String? = synchronize( { completion in
+          let result: String? = self.obj.get("test-key")
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: nil)
+      }
+    }
+    let readQueue3 = DispatchQueue(label: "ReadQueue3", attributes: [])
+    readQueue3.async {
+      for _ in 0..<400 {
+        let _: String? = synchronize( { completion in
+          let result: String? = self.obj.get("test-key")
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: nil)
+      }
+    }
+    
+    let deleteQueue = DispatchQueue(label: "deleteQueue", attributes: [])
+    deleteQueue.async {
+      for _ in 0..<400 {
+        let _: Bool = synchronize( { completion in
+          let result = self.obj.delete("test-key")
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: false)
+      }
+    }
+    
+    let deleteQueue2 = DispatchQueue(label: "deleteQueue2", attributes: [])
+    deleteQueue2.async {
+      for _ in 0..<400 {
+        let _: Bool = synchronize( { completion in
+          let result = self.obj.delete("test-key")
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: false)
+      }
+    }
+    
+    let clearQueue = DispatchQueue(label: "clearQueue", attributes: [])
+    clearQueue.async {
+      for _ in 0..<400 {
+        let _: Bool = synchronize( { completion in
+          let result = self.obj.clear()
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: false)
+      }
+    }
+    
+    let clearQueue2 = DispatchQueue(label: "clearQueue2", attributes: [])
+    clearQueue2.async {
+      for _ in 0..<400 {
+        let _: Bool = synchronize( { completion in
+          let result = self.obj.clear()
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              completion(result)
+            }
+          }
+        }, timeoutWith: false)
+      }
+    }
+    
+    let writeQueue = DispatchQueue(label: "WriteQueue", attributes: [])
+    writeQueue.async {
+      for _ in 0..<500 {
+        let written: Bool = synchronize({ completion in
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              let result = self.obj.set(dataToWrite, forKey: "test-key")
+              completion(result)
+            }
+          }
+        }, timeoutWith: false)
+        if written {
+          writes = writes + 1
+        }
+      }
+      expectation.fulfill()
+    }
+    
+    let writeQueue2 = DispatchQueue(label: "WriteQueue2", attributes: [])
+    writeQueue2.async {
+      for _ in 0..<500 {
+        let written: Bool = synchronize({ completion in
+          DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(5)) {
+              let result = self.obj.set(dataToWrite, forKey: "test-key")
+              completion(result)
+            }
+          }
+        }, timeoutWith: false)
+        if written {
+          writes = writes + 1
+        }
+      }
+      expectation2.fulfill()
+    }
+    
+    for _ in 0..<1000 {
+      self.obj.set(dataToWrite, forKey: "test-key")
+      let _ = self.obj.get("test-key")
+    }
+    self.waitForExpectations(timeout: 30, handler: nil)
+    
+    XCTAssertEqual(1000, writes)
+  }
+}
+
+// Synchronizes a asynch closure
+// Ref: https://forums.developer.apple.com/thread/11519
+func synchronize<ResultType>(_ asynchClosure: (_ completion: @escaping (ResultType) -> ()) -> Void,
+                             
+                             timeout: DispatchTime = DispatchTime.distantFuture,
+                             timeoutWith: @autoclosure @escaping () -> ResultType) -> ResultType {
+  let sem = DispatchSemaphore(value: 0)
+  
+  var result: ResultType?
+  
+  asynchClosure { (r: ResultType) -> () in
+    result = r
+    sem.signal()
+  }
+  _ = sem.wait(timeout: timeout)
+  if result == nil {
+    result = timeoutWith()
+  }
+  return result!
+}

--- a/FallingTests/LoginTest.swift
+++ b/FallingTests/LoginTest.swift
@@ -1,5 +1,5 @@
 //
-//  FallingTest.swift
+//  LoginTest.swift
 //  FallingTests
 //
 //  Created by Kanghos on 2023/08/01.
@@ -8,59 +8,46 @@
 import XCTest
 import Moya
 import RxSwift
-
 @testable import Falling
-final class FallingTest: XCTestCase {
-  private var bag = DisposeBag()
-  override func setUpWithError() throws {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-  }
 
-  override func tearDownWithError() throws {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
-
+final class LoginTest: XCTestCase {
+  private var disposeBag = DisposeBag()
+  
   func testCertificate() throws {
     AuthAPI.certificate(phoneNumber: "01089192466")
       .subscribe { response in
         print(response)
-      }.disposed(by: bag)
+      }.disposed(by: disposeBag)
     XCTWaiter().wait(for: [XCTestExpectation()], timeout: 3)
   }
-
+  
   func testLogin() throws {
     let request = makeMockLoginRequest()
     AuthAPI.login(request: request)
       .subscribe { response in
         print(response)
-      }.disposed(by: bag)
-
+      }.disposed(by: disposeBag)
+    
     XCTWaiter().wait(for: [XCTestExpectation()], timeout: 3)
-
+    
   }
   func testRx() throws {
-
+    
     let request = makeMockSignUpRequest()
-
+    
     AuthAPI.signUpRequest(request: request)
       .subscribe { response in
         print(response)
-      }.disposed(by: bag)
-
+      }.disposed(by: disposeBag)
+    
     XCTWaiter().wait(for: [XCTestExpectation()], timeout: 3)
   }
-
-  func testPerformanceExample() throws {
-    // This is an example of a performance test case.
-    self.measure {
-      // Put the code you want to measure the time of here.
-    }
-  }
+  
   func makeMockLoginRequest() -> LoginRequest {
     LoginRequest(phoneNumber: "01089192466",
                  deviceKey: 123)
   }
-
+  
   func makeMockSignUpRequest() -> SignUpRequest {
     SignUpRequest(
       phoneNumber: "01089192466",
@@ -90,5 +77,4 @@ final class FallingTest: XCTestCase {
       snsUniqueID: "snsUniqueId"
     )
   }
-
 }


### PR DESCRIPTION

## Motivation ⍰

- AccessToken을 UserDefault에 저장하는 문제 수정을 위함

<br>

## Key Changes 🔑

- 키체인 클래스를 현재 싱글톤으로 구현했습니다. KeychainSwift 라이브러리 참고하면서 기본적인 것들만 구현했습니다.
- 멀티 스레드 환경에서 객체의 멤버에 동시에 접근하는 것을 방지하기 위해서 NSLock 사용했습니다.
<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/08eea7fa-d8e6-4a84-92a4-acb91280fc92" width=60%>

- KeyChain 사용하실 때는 다음과 같이 사용하시면 됩니다.
```swift
Keychain.shared.set("토큰", forKey: "accessToken")
Keychain.shared.get("accessToken")
```
<br>

## To Reviewers 🙏🏻

- [x] 테스트 코드로 set, get, delete, clear 잘 되는지 확인해주세요.

<br>

## Linked Issue 🔗

- [x] #7
