### PR TITLE
feat: 핸드폰 인증하기 플로우 완료

### DIFF
--- a/Falling/Resources/Color.xcassets/DimColor.colorset/Contents.json
+++ b/Falling/Resources/Color.xcassets/DimColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "0x11",
+          "green" : "0x11",
+          "red" : "0x11"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Falling/Sources/Common/Application.swift
+++ b/Falling/Sources/Common/Application.swift
@@ -14,7 +14,13 @@ final class Application {
     let signUpController = UINavigationController()
     let signUpNavigator = SignUpNavigator(controller: signUpController)
     
-    guard let _ = AppData.accessToken else {
+    // TODO: 임시 토큰 저장
+    Keychain.shared.set("test", forKey: .accessToken)
+    
+    // TODO: 임시 토큰 삭제
+    Keychain.shared.delete(.accessToken)
+    
+    guard let _ = Keychain.shared.get(.accessToken) else {
       window?.rootViewController = signUpController
       signUpNavigator.toRootView()
       return

--- a/Falling/Sources/DesignUtil/FallingFont+Extension.swift
+++ b/Falling/Sources/DesignUtil/FallingFont+Extension.swift
@@ -7,6 +7,11 @@
 //
 
 import UIKit
+// Regular : weight = 400
+// Meduim : weight = 500
+// SemiBold : weight = 600
+// Bodl : weight = 700
+// ExtraBold : weight = 800
 
 extension UIFont {
 	static let thtH1R = FallingFontFamily.Pretendard.regular.font(size: 30)

--- a/Falling/Sources/Feature/SignUp/EmailInput/EmailInputViewController.swift
+++ b/Falling/Sources/Feature/SignUp/EmailInput/EmailInputViewController.swift
@@ -1,5 +1,5 @@
 //
-//  PhoneValidationViewController.swift
+//  EmailInputViewController.swift
 //  Falling
 //
 //  Created by Hoo's MacBookPro on 2023/08/06.
@@ -13,11 +13,11 @@ import RxKeyboard
 import Then
 import SnapKit
 
-class PhoneValidationViewController: TFBaseViewController {
+class EmailInputViewController: TFBaseViewController {
 		
-	private let viewModel: PhoneValidationViewModel
+	private let viewModel: EmailInputViewModel
 	
-	init(viewModel: PhoneValidationViewModel) {
+	init(viewModel: EmailInputViewModel) {
 		self.viewModel = viewModel
 		super.init(nibName: nil, bundle: nil)
 	}
@@ -36,7 +36,7 @@ class PhoneValidationViewController: TFBaseViewController {
 	}
 	
 	override func bindViewModel() {
-		let input = PhoneValidationViewModel.Input()
+		let input = EmailInputViewModel.Input()
 		let output = viewModel.transform(input: input)
 		
 		

--- a/Falling/Sources/Feature/SignUp/EmailInput/EmailInputViewModel.swift
+++ b/Falling/Sources/Feature/SignUp/EmailInput/EmailInputViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  PhoneValidationViewModel.swift
+//  EmailInputViewModel.swift
 //  Falling
 //
 //  Created by Hoo's MacBookPro on 2023/08/06.
@@ -10,7 +10,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-final class PhoneValidationViewModel: ViewModelType {
+final class EmailInputViewModel: ViewModelType {
 	
 	
 	init() { }

--- a/Falling/Sources/Feature/SignUp/Navigator/SignUpNavigator.swift
+++ b/Falling/Sources/Feature/SignUp/Navigator/SignUpNavigator.swift
@@ -29,8 +29,8 @@ final class SignUpNavigator {
 	}
 	
 	func toPhoneValidationView() {
-		let viewModel = PhoneValidationViewModel()
-		let viewController = PhoneValidationViewController(viewModel: viewModel)
+		let viewModel = EmailInputViewModel()
+		let viewController = EmailInputViewController(viewModel: viewModel)
 		
 		controller.pushViewController(viewController, animated: true)
 	}

--- a/Falling/Sources/Feature/SignUp/Navigator/SignUpNavigator.swift
+++ b/Falling/Sources/Feature/SignUp/Navigator/SignUpNavigator.swift
@@ -28,8 +28,8 @@ final class SignUpNavigator {
 		controller.pushViewController(viewcontroller, animated: true)
 	}
 	
-	func toPhoneValidationView(validationCode: Int) {
-		let viewModel = PhoneValidationViewModel(validationCode: validationCode)
+	func toPhoneValidationView() {
+		let viewModel = PhoneValidationViewModel()
 		let viewController = PhoneValidationViewController(viewModel: viewModel)
 		
 		controller.pushViewController(viewController, animated: true)
@@ -37,10 +37,11 @@ final class SignUpNavigator {
 }
 
 extension SignUpNavigator: ReactiveCompatible { }
+
 extension Reactive where Base: SignUpNavigator {
-	var toPhoneValidationView: Binder<Int> {
+	var toPhoneValidationView: Binder<Void> {
 		return Binder(base.self) { navigator, code in
-			navigator.toPhoneValidationView(validationCode: code)
+			navigator.toPhoneValidationView()
 		}
 	}
 }

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewController.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewController.swift
@@ -235,6 +235,7 @@ final class PhoneCertificationViewController: TFBaseViewController {
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		keyBoardSetting()
+    setupAccessibilityIdentifier()
 	}
 	
 	override func viewDidAppear(_ animated: Bool) {
@@ -374,5 +375,12 @@ final class PhoneCertificationViewController: TFBaseViewController {
 			})
 			.disposed(by: disposeBag)
 	}
+}
 
+extension PhoneCertificationViewController {
+  
+  private func setupAccessibilityIdentifier() {
+    phoneNumTextField.accessibilityIdentifier = AccessibilityIdentifier.phoneNumberTextField
+    verifyBtn.accessibilityIdentifier = AccessibilityIdentifier.verifyBtn
+  }
 }

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewController.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewController.swift
@@ -77,13 +77,13 @@ final class PhoneCertificationViewController: TFBaseViewController {
 	private lazy var codeInputDescLabel = UILabel().then {
 		$0.numberOfLines = 2
 		$0.font = .thtSubTitle1R
-		$0.textColor = FallingAsset.Color.netural400.color
+		$0.textColor = FallingAsset.Color.neutral400.color
 	}
 	
 	private lazy var timerLabel = UILabel().then {
 		$0.text = "00:00"
 		$0.font = .thtSubTitle1R
-		$0.textColor = FallingAsset.Color.netural50.color
+		$0.textColor = FallingAsset.Color.neutral50.color
 	}
 	
 	private lazy var codeInputTextField = UITextField().then {
@@ -93,7 +93,7 @@ final class PhoneCertificationViewController: TFBaseViewController {
 	}
 	
 	private lazy var codeInputUnderLine = UIView().then {
-		$0.backgroundColor = FallingAsset.Color.netural300.color
+		$0.backgroundColor = FallingAsset.Color.neutral300.color
 	}
 	
 	private lazy var codeInputErrDesc = UILabel().then {

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewModel.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewModel.swift
@@ -15,15 +15,27 @@ final class PhoneCertificationViewModel: ViewModelType {
 	
 	var disposeBag = DisposeBag()
 	
-	enum viewType {
+	enum ViewType {
 		case phoneNumber
 		case authCode
 	}
 	
+	struct AuthCodeWithTimeStamp {
+		let authCode: Int
+		let timeStamp = Date.now
+		
+		init(authCode: Int) {
+			self.authCode = authCode
+		}
+	}
+	
 	struct Input {
+		let viewWillAppear: Driver<Void>
 		let phoneNum: Driver<String>
 		let clearBtn: Driver<Void>
 		let verifyBtn: Driver<String>
+		let codeInput: Driver<String>
+		let finishAnimationTrigger: Driver<Void>
 	}
 	
 	struct Output {
@@ -31,9 +43,16 @@ final class PhoneCertificationViewModel: ViewModelType {
 		let validate: Driver<Bool>
 		let error: PublishRelay<Void>
 		let clearButtonTapped: Driver<String>
-		let viewStatus: Driver<viewType>
+		let viewStatus: Driver<ViewType>
+		let certificateSuccess: Driver<Bool>
+		let certificateFailuer: Driver<Bool>
+		let timeStampLabel: Driver<String>
+		let timeLabelTextColor: Driver<FallingColors>
 	}
 	
+	private var authNumber: AuthCodeWithTimeStamp = AuthCodeWithTimeStamp(authCode: 0)
+	private var timerRealy = BehaviorRelay(value: 0)
+	private var viewType: ViewType = .phoneNumber
 	private let navigator: SignUpNavigator
 	
 	init(navigator: SignUpNavigator) {
@@ -41,7 +60,12 @@ final class PhoneCertificationViewModel: ViewModelType {
 	}
 	
 	func transform(input: Input) -> Output {
+		
 		let error = PublishRelay<Void>()
+
+		let viewInit = input.viewWillAppear
+			.map { ViewType.phoneNumber }
+			.asDriver()
 		
 		let validate = input.phoneNum
 			.map { $0.phoneNumValidation() }
@@ -51,28 +75,7 @@ final class PhoneCertificationViewModel: ViewModelType {
 		let clearButtonTapped = input.clearBtn
 			.map { "" }.asDriver()
 		
-//		input.verifyBtn
-//			.throttle(.milliseconds(1500), latest: false)
-//			.asObservable()
-//			.withUnretained(self)
-//			.flatMap { vm, phoneNum -> Observable<PhoneValidationResponse> in
-////				AuthAPI.sendPhoneValidationCode(phoneNumber: phoneNum)
-////					.asObservable()
-////					.catch { _ in
-////						error.accept(Void())
-////						return .empty()
-////					}
-//				vm.testApi(pNum: phoneNum).asObservable()
-//					.catch({ _ in
-//						error.accept(Void())
-//						return .empty()
-//					})
-//			}
-//			.map({ $0.authNumber })
-//			.bind(to: navigator.rx.toPhoneValidationView)
-//			.disposed(by: disposeBag)
-		
-	let viewStatus = input.verifyBtn
+		let verifyButtonTapped = input.verifyBtn
 			.throttle(.milliseconds(1500), latest: false)
 			.asObservable()
 			.withUnretained(self)
@@ -89,16 +92,90 @@ final class PhoneCertificationViewModel: ViewModelType {
 						return .empty()
 					})
 			}
-			.map({ _ in viewType.authCode })
+			.withUnretained(self)
+			.map { vm, res in
+				vm.authNumber = AuthCodeWithTimeStamp(authCode: res.authNumber)
+				vm.viewType = .authCode
+				return Void()
+			}
+			.map({ _ in ViewType.authCode })
 			.asDriver(onErrorJustReturn: .authCode)
 		
+		let viewStatus = Driver.merge(viewInit, verifyButtonTapped)
+		
+		let inputtedCode = input.codeInput
+			.distinctUntilChanged()
+			.filter { $0.count == 6 }
+			.asObservable()
+			.withUnretained(self)
+			.map { vm, inputtedCode in
+				guard vm.isAvailableCode(vm.authNumber.timeStamp) else { return false }
+				return "\(vm.authNumber.authCode)" == inputtedCode
+			}
+			.debug()
+			.asDriver(onErrorJustReturn: false)
+		
+		let timer = Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
+			.withUnretained(self)
+			.filter { vm, _ in vm.viewType == .authCode }
+			.debug()
+			.filter { vm, _ in vm.isAvailableCode(vm.authNumber.timeStamp) }
+			.take(until: inputtedCode.filter{ $0 == true }.asObservable())
+			.share()
+			
+		let timeLabelStr = timer
+			.map { vm, _ in
+				return vm.getTimeStr(vm.authNumber.timeStamp)
+			}
+			.asDriver(onErrorJustReturn: "")
+		
+		let timerLabelColor = timer
+			.map { vm, _ in
+				if vm.isAvailableCode(vm.authNumber.timeStamp) {
+					return FallingAsset.Color.netural50
+				} else {
+					return FallingAsset.Color.error
+				}
+			}
+			.asDriver(onErrorJustReturn: FallingAsset.Color.netural50)
+		
+		input.finishAnimationTrigger
+			.debug()
+			.asDriver()
+			.drive(navigator.rx.toPhoneValidationView)
+			.disposed(by: disposeBag)
+			
 		return Output(
 			phoneNum: phoneNum,
 		  validate: validate,
 			error: error,
 			clearButtonTapped: clearButtonTapped,
-			viewStatus: viewStatus
+			viewStatus: viewStatus,
+			certificateSuccess: inputtedCode.filter { $0 == true },
+			certificateFailuer: inputtedCode.filter { $0 == false },
+			timeStampLabel: timeLabelStr,
+			timeLabelTextColor: timerLabelColor
 		)
+	}
+}
+
+extension PhoneCertificationViewModel {
+	func isAvailableCode(_ timeStamp: Date) -> Bool {
+		let timeInterval = timeStamp.timeIntervalSinceNow
+		let sec = Int(timeInterval)
+		return abs(sec) <= 180
+	}
+	
+	func getTimeStr(_ timeStamp: Date) -> String {
+		let timeInterval = timeStamp.timeIntervalSinceNow
+		let min = abs(Int(timeInterval.truncatingRemainder(dividingBy: 3600)) / 60)
+		let sec = abs(Int(timeInterval.truncatingRemainder(dividingBy: 60)))
+		
+		if sec < 10 {
+			return "0\(min):0\(sec)"
+		} else {
+			return "0\(min):\(sec)"
+		}
 	}
 }
 
@@ -108,14 +185,5 @@ extension PhoneCertificationViewModel {
 		return Single<PhoneValidationResponse>
 			.just(PhoneValidationResponse(phoneNumber: pNum, authNumber: 123456))
 			.asObservable()
-//		return Observable.create {
-//			$0.onError(MyError.testError)
-//
-//			return Disposables.create()
-//		}
 	}
-}
-
-enum MyError: Error {
-	case testError
 }

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewModel.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewModel.swift
@@ -132,12 +132,12 @@ final class PhoneCertificationViewModel: ViewModelType {
 		let timerLabelColor = timer
 			.map { vm, _ in
 				if vm.isAvailableCode(vm.authNumber.timeStamp) {
-					return FallingAsset.Color.netural50
+					return FallingAsset.Color.neutral50
 				} else {
 					return FallingAsset.Color.error
 				}
 			}
-			.asDriver(onErrorJustReturn: FallingAsset.Color.netural50)
+			.asDriver(onErrorJustReturn: FallingAsset.Color.neutral50)
 		
 		input.finishAnimationTrigger
 			.debug()

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewModel.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/PhoneCertificationViewModel.swift
@@ -60,7 +60,7 @@ final class PhoneCertificationViewModel: ViewModelType {
 		let timeStampLabel: Driver<String>
 		let timeLabelTextColor: Driver<FallingColors>
 	}
-	
+
 	private let navigator: SignUpNavigator
 	
 	init(navigator: SignUpNavigator) {
@@ -70,7 +70,6 @@ final class PhoneCertificationViewModel: ViewModelType {
 	func transform(input: Input) -> Output {
 		
 		let error = PublishRelay<Void>()
-    let viewType = BehaviorSubject<ViewType>(value: .authCode)
 		
 		let validate = input.phoneNum
 			.map { $0.phoneNumValidation() }

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/SuccessCertificationViewController.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/SuccessCertificationViewController.swift
@@ -1,0 +1,68 @@
+//
+//  SuccessCertificationViewController.swift
+//  Falling
+//
+//  Created by Hoo's MacBookPro on 2023/08/15.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+import Lottie
+
+final class SuccessCertificationView: UIView {
+	
+	private lazy var backCardView = UIView().then {
+		$0.layer.cornerRadius = 12
+		$0.backgroundColor = FallingAsset.Color.netural600.color
+	}
+	
+	private lazy var animationView = LottieAnimationView(animation: AnimationAsset.authSuccess.animation)
+	
+	private lazy var titleLabel = UILabel().then {
+		$0.font = .thtH2B
+		$0.textColor = FallingAsset.Color.netural50.color
+		$0.text = "핸드폰 번호 인증 완료"
+	}
+	
+	init() {
+		super.init(frame: .zero)
+		self.makeUI()
+	}
+	
+	func makeUI() {
+		self.backgroundColor = FallingAsset.Color.dimColor.color
+		
+		self.addSubview(backCardView)
+		
+		[animationView, titleLabel]
+			.forEach { backCardView.addSubview($0) }
+		
+		backCardView.snp.makeConstraints {
+			$0.center.equalToSuperview()
+			$0.width.equalToSuperview().multipliedBy(0.795)
+			$0.height.equalToSuperview().multipliedBy(0.536)
+		}
+		
+		animationView.snp.makeConstraints {
+			$0.centerX.equalToSuperview()
+			$0.top.equalToSuperview().offset(69)
+			$0.height.equalToSuperview().multipliedBy(0.469)
+			$0.width.equalToSuperview().multipliedBy(0.852)
+		}
+		
+		titleLabel.snp.makeConstraints {
+			$0.top.equalTo(animationView.snp.bottom).offset(34)
+			$0.centerX.equalToSuperview()
+		}
+	}
+	
+	func animationPlay(completion: @escaping () -> Void) {
+		self.animationView.play { _ in completion() }
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}

--- a/Falling/Sources/Feature/SignUp/PhoneCertification/SuccessCertificationViewController.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneCertification/SuccessCertificationViewController.swift
@@ -15,14 +15,14 @@ final class SuccessCertificationView: UIView {
 	
 	private lazy var backCardView = UIView().then {
 		$0.layer.cornerRadius = 12
-		$0.backgroundColor = FallingAsset.Color.netural600.color
+		$0.backgroundColor = FallingAsset.Color.neutral600.color
 	}
 	
 	private lazy var animationView = LottieAnimationView(animation: AnimationAsset.authSuccess.animation)
 	
 	private lazy var titleLabel = UILabel().then {
 		$0.font = .thtH2B
-		$0.textColor = FallingAsset.Color.netural50.color
+		$0.textColor = FallingAsset.Color.neutral50.color
 		$0.text = "핸드폰 번호 인증 완료"
 	}
 	

--- a/Falling/Sources/Feature/SignUp/PhoneValidation/PhoneValidationViewController.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneValidation/PhoneValidationViewController.swift
@@ -14,12 +14,7 @@ import Then
 import SnapKit
 
 class PhoneValidationViewController: TFBaseViewController {
-	// MARK: Test Code
-	private lazy var validationCodeLabel: UILabel = UILabel().then {
-		$0.font = .thtH1B
-		$0.textColor = .white
-	}
-	
+		
 	private let viewModel: PhoneValidationViewModel
 	
 	init(viewModel: PhoneValidationViewModel) {
@@ -37,19 +32,13 @@ class PhoneValidationViewController: TFBaseViewController {
 	}
 	
 	override func makeUI() {
-		view.addSubview(validationCodeLabel)
-		validationCodeLabel.snp.makeConstraints {
-			$0.center.equalToSuperview()
-			$0.height.equalTo(60)
-		}
+		
 	}
 	
 	override func bindViewModel() {
 		let input = PhoneValidationViewModel.Input()
 		let output = viewModel.transform(input: input)
 		
-		output.validationCode
-			.bind(to: validationCodeLabel.rx.text)
-			.disposed(by: disposeBag)
+		
 	}
 }

--- a/Falling/Sources/Feature/SignUp/PhoneValidation/PhoneValidationViewModel.swift
+++ b/Falling/Sources/Feature/SignUp/PhoneValidation/PhoneValidationViewModel.swift
@@ -12,13 +12,8 @@ import RxCocoa
 
 final class PhoneValidationViewModel: ViewModelType {
 	
-	private let validationCode: Int
 	
-	init(
-		validationCode: Int
-	) {
-		self.validationCode = validationCode
-	}
+	init() { }
 	
 	var disposeBag = DisposeBag()
 	
@@ -27,10 +22,10 @@ final class PhoneValidationViewModel: ViewModelType {
 	}
 	
 	struct Output {
-		let validationCode: Observable<String>
+		
 	}
 	
 	func transform(input: Input) -> Output {
-		return Output(validationCode: Observable.just("\(validationCode)"))
+		return Output()
 	}
 }

--- a/Falling/Sources/Feature/SignUp/SignUpRoot/SignUpRootViewController.swift
+++ b/Falling/Sources/Feature/SignUp/SignUpRoot/SignUpRootViewController.swift
@@ -37,6 +37,7 @@ final class SignUpRootViewController: TFBaseViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
+    setupAccessibilityIdentifier()
 	}
 	
 	override func makeUI() {
@@ -83,6 +84,16 @@ final class SignUpRootViewController: TFBaseViewController {
 	deinit {
 		print("[Deinit]: \(self)")
 	}
+}
+
+extension SignUpRootViewController {
+  
+  private func setupAccessibilityIdentifier() {
+    startPhoneBtn.accessibilityIdentifier = AccessibilityIdentifier.phoneBtn
+    startKakaoButton.accessibilityIdentifier = AccessibilityIdentifier.kakoBtn
+    startNaverBtn.accessibilityIdentifier = AccessibilityIdentifier.naverBtn
+    startGoogleBtn.accessibilityIdentifier = AccessibilityIdentifier.googleBtn
+  }
 }
 
 //struct SignUpRootViewControllerPreview: PreviewProvider {

--- a/Falling/Sources/Feature/SignUp/SignUpRoot/SignUpRootViewController.swift
+++ b/Falling/Sources/Feature/SignUp/SignUpRoot/SignUpRootViewController.swift
@@ -16,13 +16,13 @@ final class SignUpRootViewController: TFBaseViewController {
 		$0.spacing = 16
 	}
 	
-	private lazy var startPhoneBtn: LoginButton = LoginButton(btnType: .phone)
+	private lazy var startPhoneBtn = TFLoginButton(btnType: .phone)
 	
-	private lazy var startKakaoButton: LoginButton = LoginButton(btnType: .kakao)
+	private lazy var startKakaoButton = TFLoginButton(btnType: .kakao)
 	
-	private lazy var startGoogleBtn: LoginButton = LoginButton(btnType: .google)
+	private lazy var startGoogleBtn = TFLoginButton(btnType: .google)
 	
-	private lazy var startNaverBtn: LoginButton = LoginButton(btnType: .naver)
+	private lazy var startNaverBtn = TFLoginButton(btnType: .naver)
 	
 	private lazy var signitureImageView: UIImageView = UIImageView(image: FallingAsset.Bx.signitureVertical.image).then {
 		$0.contentMode = .scaleAspectFit

--- a/Falling/Sources/Feature/SignUp/SubViews/LoginButton.swift
+++ b/Falling/Sources/Feature/SignUp/SubViews/LoginButton.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-enum LoginButtonType {
+enum TFLoginButtonType {
 	case phone
 	case kakao
 	case google
@@ -64,10 +64,10 @@ enum LoginButtonType {
 //	}
 }
 
-final class LoginButton: UIButton {
-	let btnType: LoginButtonType
+final class TFLoginButton: UIButton {
+	let btnType: TFLoginButtonType
 	
-	init(btnType: LoginButtonType) {
+	init(btnType: TFLoginButtonType) {
 		self.btnType = btnType
 		super.init(frame: .zero)
 		

--- a/Falling/Sources/Feature/SignUp/SubViews/TFTextButton.swift
+++ b/Falling/Sources/Feature/SignUp/SubViews/TFTextButton.swift
@@ -1,0 +1,43 @@
+//
+//  TFTextButton.swift
+//  Falling
+//
+//  Created by Hoo's MacBookPro on 2023/08/13.
+//
+
+import UIKit
+
+final class TFTextButton: UIButton {
+	let title: String
+	
+	init(title: String) {
+		self.title = title
+		super.init(frame: .zero)
+		makeView()
+	}
+	
+	func makeView() {
+		let attributedString = NSMutableAttributedString(string: title)
+		attributedString.addAttribute(.underlineStyle,
+																	value: NSUnderlineStyle.single.rawValue,
+																	range: NSRange(location: 0, length: title.count))
+		
+		attributedString.addAttribute(.font,
+																	value: UIFont.thtP2M,
+																	range: NSRange(location: 0, length: title.count))
+	
+		attributedString.addAttribute(.underlineColor,
+																	value: FallingAsset.Color.netural400.color,
+																	range: NSRange(location: 0, length: title.count))
+		
+		attributedString.addAttribute(.foregroundColor,
+																	value: FallingAsset.Color.netural400.color,
+																	range: NSRange(location: 0, length: title.count))
+		
+		setAttributedTitle(attributedString, for: .normal)
+	}
+	
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+}

--- a/Falling/Sources/Feature/SignUp/SubViews/TFTextButton.swift
+++ b/Falling/Sources/Feature/SignUp/SubViews/TFTextButton.swift
@@ -27,11 +27,11 @@ final class TFTextButton: UIButton {
 																	range: NSRange(location: 0, length: title.count))
 	
 		attributedString.addAttribute(.underlineColor,
-																	value: FallingAsset.Color.netural400.color,
+																	value: FallingAsset.Color.neutral400.color,
 																	range: NSRange(location: 0, length: title.count))
 		
 		attributedString.addAttribute(.foregroundColor,
-																	value: FallingAsset.Color.netural400.color,
+																	value: FallingAsset.Color.neutral400.color,
 																	range: NSRange(location: 0, length: title.count))
 		
 		setAttributedTitle(attributedString, for: .normal)

--- a/Falling/Sources/Util/AccessibilityIdentifier.swift
+++ b/Falling/Sources/Util/AccessibilityIdentifier.swift
@@ -1,0 +1,19 @@
+//
+//  AccessibilityIdentifier.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/08/21.
+//
+
+struct AccessibilityIdentifier {
+  
+  // SignUpVC
+  static let phoneBtn = "phoneBtn"
+  static let kakoBtn = "kakoBtn"
+  static let naverBtn = "naverBtn"
+  static let googleBtn = "googleBtn"
+  
+  // PhoneCertificationVC
+  static let phoneNumberTextField = "phoneNumberTextField"
+  static let verifyBtn = "verifyBtn"
+}

--- a/FallingUITests/FallingUITestsLaunchTests.swift
+++ b/FallingUITests/FallingUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  FallingUITestsLaunchTests.swift
+//  FallingUITests
+//
+//  Created by SeungMin on 2023/08/21.
+//
+
+import XCTest
+
+final class FallingUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/FallingUITests/LoginTest.swift
+++ b/FallingUITests/LoginTest.swift
@@ -1,0 +1,57 @@
+//
+//  FallingUITests.swift
+//  FallingUITests
+//
+//  Created by SeungMin on 2023/08/21.
+//
+
+import XCTest
+@testable import Falling
+
+final class FallingUITests: XCTestCase {
+  
+  var app: XCUIApplication!
+  var phoneBtn: XCUIElement!
+  var kakoBtn: XCUIElement!
+  var naverBtn: XCUIElement!
+  var googleBtn: XCUIElement!
+  var phoneNumberTextField: XCUIElement!
+  var verifyBtn: XCUIElement!
+  
+  override func setUpWithError() throws {
+    app = XCUIApplication()
+    phoneBtn = app.buttons[AccessibilityIdentifier.phoneBtn]
+    kakoBtn = app.buttons[AccessibilityIdentifier.kakoBtn]
+    naverBtn = app.buttons[AccessibilityIdentifier.naverBtn]
+    googleBtn = app.buttons[AccessibilityIdentifier.googleBtn]
+    phoneNumberTextField = app.textFields[AccessibilityIdentifier.phoneNumberTextField]
+    verifyBtn = app.buttons[AccessibilityIdentifier.verifyBtn]
+    
+    Keychain.shared.clear()
+    continueAfterFailure = false
+    
+    app.launch()
+  }
+  
+  override func tearDownWithError() throws {
+    app = nil
+    phoneBtn = nil
+    kakoBtn = nil
+    naverBtn = nil
+    googleBtn = nil
+  }
+  
+  func testPhoneAuthenticationSuccess() throws {
+    let input = "01011112222"
+    
+    phoneBtn.tap()
+    
+    phoneNumberTextField.tap()
+
+    input.forEach { app.keys[String($0)].tap() }
+    
+    verifyBtn.tap()
+    
+    Thread.sleep(forTimeInterval: 1)
+  }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -15,14 +15,14 @@ import ProjectDescriptionHelpers
  |   Kit    |                   |     UI    |   Two independent frameworks to share code and start modularising your app
  |          |                   |           |
  +----------+                   +-----------+
-
+ 
  */
 
 // MARK: - ProjectFactory
 protocol ProjectFactory {
   var projectName: String { get }
   //    var dependencies: [TargetDependency] { get }
-
+  
   func generateTarget() -> [Target]
   //  func generateConfigurations() -> Settings
 }
@@ -33,7 +33,7 @@ final class BaseProjectFactory: ProjectFactory {
   let organizationName: String = ""
   let bundleID: String = "com.tht.falling.Falling"
   let targetVersion: String = "16.1"
-
+  
   let dependencies: [TargetDependency] = [
     .external(name: "SnapKit"),
     .external(name: "Then"),
@@ -46,9 +46,9 @@ final class BaseProjectFactory: ProjectFactory {
     .external(name: "Moya"),
     .external(name: "RxMoya"),
     .external(name: "FirebaseStorage"),
-		.external(name: "RxGesture")
+    .external(name: "RxGesture")
   ]
-
+  
   let infoPlist: [String: InfoPlist.Value] = [
     "CFBundleName": "THT",
     "CFBundleShortVersionString": "1.0.0",
@@ -77,8 +77,8 @@ final class BaseProjectFactory: ProjectFactory {
     ],
     "UIUserInterfaceStyle": "Dark"
   ]
-
-
+  
+  
   let projectSettings: Settings = .settings(
     base: [
       "OTHER_LDFLAGS": "-ObjC",
@@ -88,7 +88,7 @@ final class BaseProjectFactory: ProjectFactory {
       ]
     ]
   )
-
+  
   let resourceSynthesizers: [ResourceSynthesizer] = [
     .custom(
       name: "Lottie",
@@ -98,7 +98,7 @@ final class BaseProjectFactory: ProjectFactory {
     .assets(),
     .fonts(),
   ]
-
+  
   //  /Users/kanghos/Desktop/iOS/tuist-test/Projects/App/Support
   func generateTarget() -> [Target] {
     return [
@@ -113,7 +113,7 @@ final class BaseProjectFactory: ProjectFactory {
              dependencies: dependencies,
              settings: projectSettings
             ),
-
+      
       Target(name: "\(projectName)Tests",
              platform: .iOS,
              product: .unitTests,
@@ -122,10 +122,20 @@ final class BaseProjectFactory: ProjectFactory {
              sources: ["\(projectName)Tests/**"],
              dependencies: [.target(name: projectName)],
              settings: projectSettings
-            )
+            ),
+      
+      Target(name: "\(projectName)UITests",
+             platform: .iOS,
+             product: .uiTests,
+             bundleId: "com.tht.\(projectName).UITests",
+             infoPlist: .extendingDefault(with: infoPlist),
+             sources: ["\(projectName)UITests/**"],
+             dependencies: [.target(name: projectName)],
+             settings: projectSettings
+            ),
     ]
   }
-
+  
   //      func generateConfigurations() -> Settings {
   //          Setting.settings(configurations: [
   //              .debug(name: , xcconfig: ),

--- a/Project.swift
+++ b/Project.swift
@@ -46,6 +46,7 @@ final class BaseProjectFactory: ProjectFactory {
     .external(name: "Moya"),
     .external(name: "RxMoya"),
     .external(name: "FirebaseStorage"),
+		.external(name: "RxGesture")
   ]
 
   let infoPlist: [String: InfoPlist.Value] = [

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -10,6 +10,7 @@ let spm = SwiftPackageManagerDependencies([
     .remote(url: "https://github.com/onevcat/Kingfisher.git", requirement: .upToNextMajor(from: "7.0.0")),
     .remote(url: "https://github.com/airbnb/lottie-spm.git", requirement: .upToNextMajor(from: "4.0.0")),
     .remote(url: "https://github.com/firebase/firebase-ios-sdk.git", requirement: .exact("10.10.0")),
+		.remote(url: "https://github.com/RxSwiftCommunity/RxGesture.git", requirement: .upToNextMajor(from: "4.0.0"))
 ])
 
 


### PR DESCRIPTION
- email 인증 화면 (비어있는 화면) 으로 넘어가게끔 해놓음

## Motivation ⍰

- 핸드폰 인증하기 화면

<br>

## Key Changes 🔑

- 인증하기 화면 부분 input output 패턴 재정비
- 인증완료 이후 lottie popup 완료
- popup 이후 callback 이용, input trigger 에 vc push 하는 로직 추가

<br>

## To Reviewers 🙏🏻

- [ ] lottie 에서 callback 받아오는 부분에 대해 의문이 있습니다. 이런 패턴이 맞을지 한번 확인부탁 드립니다.
- [ ] input output 패턴 이용시 viewModel 의 transform 에서는 dispose 되지 않도록 하는것 이라고 알고 있는데, navigator 을 이용할 시 dispose 해줘야하는 input stream 이 있는것으로 보입니다 이부분에 대한 논의가 필요해 보입니다.

<br>

## Linked Issue 🔗

- https://github.com/THT-Team/THT-iOS/issues/12#issue-1838190900
