### PR TITLE
[#26]Refactor: 토픽 바 텍스트 동적 높이 설정

### DIFF
--- a/Falling/Sources/Foundation/Component/TFPaddingLabel.swift
+++ b/Falling/Sources/Foundation/Component/TFPaddingLabel.swift
@@ -9,8 +9,8 @@ import UIKit
 
 final class TFPaddingLabel: UILabel {
 
-  private static let defaultPadding = UIEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
-  private var padding: UIEdgeInsets = UIEdgeInsets(top: 4, left: 10, bottom: 4, right: 10)
+  private static let defaultPadding = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
+  private var padding: UIEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
   convenience init(padding: UIEdgeInsets? = nil) {
     self.init()
 

--- a/Falling/Sources/Foundation/Component/TFTopicBarView.swift
+++ b/Falling/Sources/Foundation/Component/TFTopicBarView.swift
@@ -10,6 +10,14 @@ import UIKit
 import SnapKit
 
 final class TFTopicBarView: TFBaseView {
+  private lazy var stackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.spacing = 10
+    stackView.distribution = .fill
+    stackView.alignment = .center
+    return stackView
+  }()
   private lazy var titleLabel: TFPaddingLabel = {
     let label = TFPaddingLabel()
     label.layer.borderWidth = 1
@@ -25,7 +33,8 @@ final class TFTopicBarView: TFBaseView {
     let label = UILabel()
     label.textColor = FallingAsset.Color.neutral50.color
     label.font = UIFont.thtSubTitle2Sb
-    label.numberOfLines = 0
+    label.numberOfLines = 2
+    label.textAlignment = .left
     label.lineBreakMode = .byCharWrapping
     return label
   }()
@@ -55,26 +64,19 @@ final class TFTopicBarView: TFBaseView {
     self.backgroundColor = UIColor(named: "TopicBackground")
     self.layer.borderWidth = 1
     self.layer.borderColor = UIColor(named: "TopicBorder")?.cgColor
-    
-    self.addSubviews([titleLabel, contentLabel, closeButton])
-    
-    titleLabel.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
-    titleLabel.snp.makeConstraints {
-      $0.leading.equalToSuperview().offset(12)
-      $0.height.equalTo(35)
-      $0.centerY.equalToSuperview()
-    }
-    contentLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
-    contentLabel.snp.makeConstraints {
-      $0.centerY.equalToSuperview()
-      $0.top.bottom.equalToSuperview().inset(14)
-      $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
+
+    stackView.addArrangedSubviews([titleLabel, contentLabel])
+    self.addSubviews([stackView, closeButton])
+
+    stackView.snp.makeConstraints {
+      $0.leading.equalToSuperview().offset(10)
+      $0.top.bottom.equalToSuperview().inset(8)
       $0.trailing.equalTo(closeButton.snp.leading).offset(-8)
     }
     closeButton.snp.makeConstraints {
       $0.size.equalTo(18)
       $0.centerY.equalToSuperview()
-      $0.trailing.equalToSuperview().inset(20)
+      $0.trailing.equalToSuperview().inset(14)
     }
   }
   
@@ -84,13 +86,6 @@ final class TFTopicBarView: TFBaseView {
     titleLabel.layer.masksToBounds = true
     titleLabel.layoutIfNeeded()
 
-    contentLabel.snp.remakeConstraints({
-      $0.centerY.equalToSuperview()
-      $0.top.bottom.equalToSuperview().inset(14)
-      $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
-      $0.trailing.equalTo(closeButton.snp.leading).offset(-8)
-      $0.height.lessThanOrEqualTo(round(contentLabel.font.lineHeight) * 2)
-    })
   }
   
   func configure(title: String, content: String) {

--- a/Falling/Sources/Foundation/Component/TFTopicBarView.swift
+++ b/Falling/Sources/Foundation/Component/TFTopicBarView.swift
@@ -83,6 +83,14 @@ final class TFTopicBarView: TFBaseView {
     titleLabel.layer.cornerRadius = titleLabel.frame.height / 2
     titleLabel.layer.masksToBounds = true
     titleLabel.layoutIfNeeded()
+
+    contentLabel.snp.remakeConstraints({
+      $0.centerY.equalToSuperview()
+      $0.top.bottom.equalToSuperview().inset(14)
+      $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
+      $0.trailing.equalTo(closeButton.snp.leading).offset(-8)
+      $0.height.lessThanOrEqualTo(round(contentLabel.font.lineHeight) * 2)
+    })
   }
   
   func configure(title: String, content: String) {


### PR DESCRIPTION
## Motivation ⍰

- 토픽 텍스트 라벨 2줄까지 동적 높이 설정 위함

<br>

## Key Changes 🔑

- layoutSubviews()에서 라벨의 제약조건을 remakeConstraints로 재설정할 때, 최대 높이를 두 줄로 설정하는 방식으로 수정
코드는 다음과 같음
```swift
// TFTopicBarView
override func layoutSubviews() {
  contentLabel.snp.remakeConstraints({
    $0.centerY.equalToSuperview()
    $0.top.bottom.equalToSuperview().inset(14)
    $0.leading.equalTo(titleLabel.snp.trailing).offset(8)
    $0.trailing.equalTo(closeButton.snp.leading).offset(-8)
    $0.height.lessThanOrEqualTo(round(contentLabel.font.lineHeight) * 2)
  })
}
```

텍스트 라벨의 numberOfLines를 0으로 설정하고, contentLabel.font.lineHeight으로 한 줄 높이를 가져오는 방식으로 구현했습니다.
처음에는 2줄 이상일 때, 라인 간 간격 값이 존재하다고 생각했는데 intrinsic content size 높이를 보니 따로 없는 것을 확인했습니다.
cgfloat값이라 반올림을 했는데, 4, 5줄 이상부터는 오차가 발생하긴 합니다.
그런데 어차피 2줄까지라서 동일한 수치로 표시할 수 있습니다.

|1줄|2줄|
|:---:|:---:|
|<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/bd485712-600f-445f-a111-ae5cd39b9f1b" width=100%>|<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/d544de5d-4e74-4c82-85c8-c49002f1885a" width=80%>|
|<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/e39ad1a1-2a16-4cae-929f-e44a3e90e4c6" width=80%>|<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/18c31055-7c56-49c4-a1b4-796a167c39e5" width=80%>|


<br>

## To Reviewers 🙏🏻

- [ ] 한 줄이 원하는 디자인대로 나오는 지 확인해주세요
- [x] 두 줄 이상일 때, 원하는 디자인대로 나오는 지 확인해주세요

<br>

## Linked Issue 🔗

- 
