### PR TITLE
[#34]Fix: 노치 없는 폰에서 하단 네비 바 짤림 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/🔴-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/🔴-bug-report.md
@@ -10,8 +10,7 @@ assignees: ''
 ## Detail
 - 
 
-## Cause
-- 
-
-## Solution
--
+## Environment
+- Mac: 
+- Xcode: 
+- Device: 

--- a/Falling/Sources/Base/TFBaseViewController.swift
+++ b/Falling/Sources/Base/TFBaseViewController.swift
@@ -10,23 +10,23 @@ import UIKit
 import RxSwift
 
 class TFBaseViewController: UIViewController {
-	
-	var disposeBag = DisposeBag()
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		view.backgroundColor = FallingAsset.Color.neutral700.color
-		navigationSetting()
-		makeUI()
-		bindViewModel()
-	}
-	
+  
+  var disposeBag = DisposeBag()
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = FallingAsset.Color.neutral700.color
+    navigationSetting()
+    makeUI()
+    bindViewModel()
+  }
+  
   /// Set up Navigation Bar
-	func navigationSetting() {
-		navigationController?.navigationBar.topItem?.title = ""
-		navigationController?.navigationBar.backIndicatorImage = FallingAsset.Image.chevron.image
-		navigationController?.navigationBar.backIndicatorTransitionMaskImage = FallingAsset.Image.chevron.image
-		navigationController?.navigationBar.tintColor = FallingAsset.Color.neutral50.color
+  func navigationSetting() {
+    navigationController?.navigationBar.topItem?.title = ""
+    navigationController?.navigationBar.backIndicatorImage = FallingAsset.Image.chevron.image
+    navigationController?.navigationBar.backIndicatorTransitionMaskImage = FallingAsset.Image.chevron.image
+    navigationController?.navigationBar.tintColor = FallingAsset.Color.neutral50.color
     
     let navBarAppearance = UINavigationBarAppearance()
     navBarAppearance.titlePositionAdjustment.horizontal = -CGFloat.greatestFiniteMagnitude
@@ -35,7 +35,7 @@ class TFBaseViewController: UIViewController {
     navBarAppearance.shadowColor = nil
     navigationItem.standardAppearance = navBarAppearance
     navigationItem.scrollEdgeAppearance = navBarAppearance
-	}
+  }
   
   /// call in super viewDidLoad
   func makeUI() { }

--- a/Falling/Sources/Common/Application.swift
+++ b/Falling/Sources/Common/Application.swift
@@ -32,7 +32,7 @@ final class Application {
   
   private func makeTabBarController() -> UIViewController {
     let heartService = HeartAPI(isStub: true, sampleStatusCode: 200, customEndpointClosure: nil)
-
+    
     let mainNavigationController = UINavigationController()
     let heartNavigationController = UINavigationController()
     let chatNavigationController = UINavigationController()
@@ -81,7 +81,6 @@ final class Application {
       image: image,
       selectedImage: selectedImage
     )
-    navigationController.tabBarItem.imageInsets = .init(top: 5, left: 0, bottom: -5, right: 0)
     return navigationController
   }
 }

--- a/Falling/Sources/Feature/Main/MainViewController.swift
+++ b/Falling/Sources/Feature/Main/MainViewController.swift
@@ -18,6 +18,10 @@ final class MainViewController: TFBaseViewController {
     super.init(nibName: nil, bundle: nil)
   }
   
+  override func loadView() {
+    self.view = mainView
+  }
+  
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
@@ -35,13 +39,9 @@ final class MainViewController: TFBaseViewController {
     navigationItem.rightBarButtonItem = notificationButtonItem
   }
   
-  override func loadView() {
-    self.view = mainView
-  }
-  
   override func bindViewModel() {
     let output = viewModel.transform(input: MainViewModel.Input())
-
+    
     output.state
       .drive(mainView.rx.timeState)
       .disposed(by: disposeBag)

--- a/Falling/Sources/Foundation/TabBar/TFTabBarController.swift
+++ b/Falling/Sources/Foundation/TabBar/TFTabBarController.swift
@@ -10,11 +10,11 @@ import UIKit
 import RxSwift
 
 protocol TabBarDependnecy: AnyObject {
-
+  var tabBarHeight: CGFloat { get }
 }
 
 final class TabBarComponent: TabBarDependnecy {
-
+  var tabBarHeight: CGFloat = 56
 }
 
 final class TFTabBarController: UITabBarController {
@@ -30,33 +30,35 @@ final class TFTabBarController: UITabBarController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-
     setAppearance()
+  }
+  
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    tabBar.frame.size.height = dependnecy.tabBarHeight + UIWindow.safeAreaInsetBottom
+    tabBar.frame.origin.y = self.view.frame.height - dependnecy.tabBarHeight - UIWindow.safeAreaInsetBottom
   }
 
 // https://emptytheory.com/2019/12/31/using-uitabbarappearance-for-tab-bar-changes-in-ios-13/
   private func setAppearance() {
-    let appearence = UITabBarAppearance()
-
-    appearence.backgroundColor = FallingAsset.Color.neutral700.color
-    appearence.shadowColor = FallingAsset.Color.neutral600.color
+    let tabBarAppearance = UITabBarAppearance()
+    tabBarAppearance.backgroundColor = FallingAsset.Color.neutral700.color
+    tabBarAppearance.shadowColor = FallingAsset.Color.neutral600.color
     self.tabBar.isTranslucent = false
 
-    setTabItemAppearence(appearence.stackedLayoutAppearance)
-    self.tabBar.scrollEdgeAppearance = appearence
-    self.tabBar.standardAppearance = appearence
+    setTabItemAppearence(tabBarAppearance.stackedLayoutAppearance)
+    self.tabBar.standardAppearance = tabBarAppearance
+    self.tabBar.scrollEdgeAppearance = tabBarAppearance
   }
 
-  private func setTabItemAppearence(_ itemAppearence: UITabBarItemAppearance) {
-    itemAppearence.normal.titleTextAttributes = [
+  private func setTabItemAppearence(_ itemAppearance: UITabBarItemAppearance) {
+    itemAppearance.normal.titleTextAttributes = [
       .foregroundColor: FallingAsset.Color.unSelected.color,
       .font: UIFont.thtCaption1M
     ]
-    itemAppearence.normal.titlePositionAdjustment.vertical = 10
-    itemAppearence.selected.titleTextAttributes = [
+    itemAppearance.selected.titleTextAttributes = [
       .foregroundColor: FallingAsset.Color.neutral50.color,
       .font: UIFont.thtCaption1M
     ]
-
   }
 }

--- a/Falling/Sources/Foundation/TabBar/TFTabBarController.swift
+++ b/Falling/Sources/Foundation/TabBar/TFTabBarController.swift
@@ -36,7 +36,7 @@ final class TFTabBarController: UITabBarController {
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
     tabBar.frame.size.height = dependnecy.tabBarHeight + UIWindow.safeAreaInsetBottom
-    tabBar.frame.origin.y = self.view.frame.height - dependnecy.tabBarHeight - UIWindow.safeAreaInsetBottom
+    tabBar.frame.origin.y = self.view.frame.height - tabBar.frame.size.height
   }
 
 // https://emptytheory.com/2019/12/31/using-uitabbarappearance-for-tab-bar-changes-in-ios-13/

--- a/Falling/Sources/Util/UIWindow+Utils.swift
+++ b/Falling/Sources/Util/UIWindow+Utils.swift
@@ -1,0 +1,23 @@
+//
+//  UIWindow+Utils.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/09/27.
+//
+
+import UIKit
+
+extension UIWindow {
+  
+  static var keyWindow: UIWindow? {
+    return UIApplication
+      .shared
+      .connectedScenes
+      .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+      .last
+  }
+  
+  static var safeAreaInsetBottom: CGFloat {
+    return (UIWindow.keyWindow?.safeAreaInsets.bottom ?? 0)
+  }
+}


### PR DESCRIPTION
## Motivation ⍰

- 노치 없는 폰에서 하단 네비 바 짤림

<br>

## Key Changes 🔑

- 탭 바 높이가 기본적으로 49로 확인이 되서 56으로 높이를 수정하는 코드를 추가했습니다.
(Human Interface Guidelines에서 탭 바 높이에 대해서는 따로 제한이 없는 것으로 확인했습니다.)
코드는 다음과 같습니다.
```swift
protocol TabBarDependnecy: AnyObject {
  var tabBarHeight: CGFloat { get }
}

final class TabBarComponent: TabBarDependnecy {
  var tabBarHeight: CGFloat = 56 // dependnecy에 tabBarHeight 추가
}

final class TFTabBarController: UITabBarController {
  {...}
  
  override func viewDidLayoutSubviews() {
    super.viewDidLayoutSubviews()
    // 탭 바 높이(56) + 노치 높이(바텀 Inset)
    tabBar.frame.size.height = dependnecy.tabBarHeight + UIWindow.safeAreaInsetBottom
    // (view의 높이 - 수정된 탭 바 높이)로 탭바 y 값 갱신
    tabBar.frame.origin.y = self.view.frame.height - tabBar.frame.size.height
  }
}
```

미리보기는 다음과 같습니다.
|iPhone 14 pro|iPhone SE 3rd|
|:---:|:---:|
|<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/95cc2c69-4256-4117-9acd-1ed1f6763016" width=60%>|<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/6a218bc7-d39c-4658-9829-4ed75fb52191" width=60%>|

<br>

## To Reviewers 🙏🏻

- [x] 노치 있는 폰, 없는 폰에서 탭 바가 디자인과 일치해서 나오는 지 확인해주세요.

<br>

## Linked Issue 🔗

- [x] #34 
