### PR TITLE
[#35] 현재 보이는 유저 카드 셀에서의 타임이 0이 되면 자동으로 다음 셀로 스크롤 구현

### DIFF
--- a/Falling/Sources/Base/TFBaseCollectionViewCell.swift
+++ b/Falling/Sources/Base/TFBaseCollectionViewCell.swift
@@ -1,0 +1,31 @@
+//
+//  TFBaseCollectionViewCell.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/10/02.
+//
+
+import UIKit
+
+import RxSwift
+
+class TFBaseCollectionViewCell: UICollectionViewCell {
+  
+  var disposeBag = DisposeBag()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    makeUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    self.disposeBag = DisposeBag()
+  }
+  
+  func makeUI() { }
+}

--- a/Falling/Sources/DataLayer/API/MainAPI/DTO/UserResponse.swift
+++ b/Falling/Sources/DataLayer/API/MainAPI/DTO/UserResponse.swift
@@ -1,0 +1,24 @@
+//
+//  UserResponse.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/10/06.
+//
+
+struct UserResponse: Codable {
+  let userList: [UserDTO]
+}
+
+struct UserDTO: Codable {
+  let userIdx: Int
+//  enum CodingKeys: CodingKey {
+//    
+//  }
+}
+
+struct UserSectionMapper {
+  static func map(list: [UserDTO]) -> [UserSection] {
+    let mutableSection: [UserSection] = []
+    return mutableSection
+  }
+}

--- a/Falling/Sources/Feature/Main/Cell/MainCollectionViewCell.swift
+++ b/Falling/Sources/Feature/Main/Cell/MainCollectionViewCell.swift
@@ -98,8 +98,8 @@ final class MainCollectionViewCell: TFBaseCollectionViewCell {
     disposeBag = DisposeBag()
   }
   
-  func setup(item: UserDTO) {
-    viewModel = MainCollectionViewItemViewModel(userDTO: item)
+  func setup(item: UserDomain) {
+    viewModel = MainCollectionViewItemViewModel(userDomain: item)
   }
   
   func bindViewModel() {

--- a/Falling/Sources/Feature/Main/Cell/MainCollectionViewCell.swift
+++ b/Falling/Sources/Feature/Main/Cell/MainCollectionViewCell.swift
@@ -1,0 +1,131 @@
+//
+//  UserCollectionViewCell.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/10/02.
+//
+
+import UIKit
+import RxSwift
+
+final class MainCollectionViewCell: TFBaseCollectionViewCell {
+  
+  lazy var userImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.image = .add
+    return imageView
+  }()
+  
+  lazy var userContentView: UIView = {
+    let view = UIView()
+    view.backgroundColor = FallingAsset.Color.clear.color
+    return view
+  }()
+  
+  lazy var progressContainerView: UIView = {
+    let view = UIView()
+    view.layer.cornerRadius = 15
+    view.backgroundColor = FallingAsset.Color.dimColor.color.withAlphaComponent(0.5)
+    return view
+  }()
+  
+  lazy var timerView = CardTimerView()
+  
+  lazy var progressView = CardProgressView()
+  
+  override func layoutSubviews() {
+    self.backgroundColor = .systemGray
+  }
+  
+  override func makeUI() {
+    // TODO: cornerRadius 동적으로 설정해야 할 것.
+    self.layer.cornerRadius = 15
+    
+    self.addSubview(userImageView)
+    self.addSubview(userContentView)
+    
+    self.userContentView.addSubview(progressContainerView)
+    
+    self.progressContainerView.addSubviews([
+      timerView,
+      progressView
+    ])
+    
+    self.userImageView.snp.makeConstraints {
+      $0.top.equalToSuperview()
+      $0.leading.equalToSuperview()
+      $0.bottom.equalToSuperview()
+      $0.trailing.equalToSuperview()
+    }
+    
+    self.userContentView.snp.makeConstraints {
+      $0.top.equalToSuperview()
+      $0.leading.equalToSuperview()
+      $0.bottom.equalToSuperview()
+      $0.trailing.equalToSuperview()
+    }
+    
+    self.progressContainerView.snp.makeConstraints {
+      $0.top.equalTo(self.safeAreaLayoutGuide).inset(12)
+      $0.leading.trailing.equalToSuperview().inset(12)
+      $0.height.equalTo(32)
+    }
+    
+    self.timerView.snp.makeConstraints {
+      $0.leading.equalToSuperview().inset(9)
+      $0.centerY.equalToSuperview()
+      $0.width.equalTo(22)
+      $0.height.equalTo(22)
+    }
+    
+    self.progressView.snp.makeConstraints {
+      $0.leading.equalTo(timerView.snp.trailing).offset(9)
+      $0.trailing.equalToSuperview().inset(12)
+      $0.centerY.equalToSuperview()
+      $0.height.equalTo(6)
+    }
+  }
+  
+  func dotPosition(progress: Double, rect: CGRect) -> CGPoint {
+    var progress = progress
+    // progress가 -0.05미만 혹은 1이상은 점(dot)을 0초에 위치시키기 위함
+    let strokeRange: Range<Double> = -0.05..<0.95
+    if !(strokeRange ~= progress) { progress = 0.95 }
+    let radius = CGFloat(rect.height / 2 - timerView.strokeLayer.lineWidth / 2)
+    let angle = 2 * CGFloat.pi * CGFloat(progress) - CGFloat.pi / 2
+    let dotX = radius * cos(angle + 0.35)
+    let dotY = radius * sin(angle + 0.35)
+    
+    let point = CGPoint(x: dotX, y: dotY)
+    
+    return CGPoint(
+      x: rect.midX + point.x,
+      y: rect.midY + point.y
+    )
+  }
+}
+
+extension Reactive where Base: MainCollectionViewCell {
+  var timeState: Binder<MainViewModel.TimeState> {
+    return Binder(self.base) { (base, timeState) in
+      base.timerView.trackLayer.strokeColor = timeState.fillColor.color.cgColor
+      base.timerView.strokeLayer.strokeColor = timeState.color.color.cgColor
+      base.timerView.dotLayer.strokeColor = timeState.color.color.cgColor
+      base.timerView.dotLayer.fillColor = timeState.color.color.cgColor
+      base.timerView.timerLabel.textColor = timeState.color.color
+      base.progressView.progressBarColor = timeState.color.color
+      
+      base.timerView.dotLayer.isHidden = timeState.isDotHidden
+      
+      base.timerView.timerLabel.text = timeState.getText
+      
+      base.progressView.progress = CGFloat(timeState.getProgress)
+      
+      // TimerView Animation은 소수점 둘째 자리까지 표시해야 오차가 발생하지 않음
+      let strokeEnd = round(CGFloat(timeState.getProgress) * 100) / 100
+      base.timerView.dotLayer.position = base.dotPosition(progress: strokeEnd, rect: base.timerView.bounds)
+      
+      base.timerView.strokeLayer.strokeEnd = strokeEnd
+    }
+  }
+}

--- a/Falling/Sources/Feature/Main/Cell/MainCollectionViewItemViewModel.swift
+++ b/Falling/Sources/Feature/Main/Cell/MainCollectionViewItemViewModel.swift
@@ -12,10 +12,10 @@ import RxCocoa
 
 final class MainCollectionViewItemViewModel: ViewModelType {
   
-  let userDTO: UserDTO
+  let userDomain: UserDomain
   
-  init(userDTO: UserDTO) {
-    self.userDTO = userDTO
+  init(userDomain: UserDomain) {
+    self.userDomain = userDomain
   }
   
   enum TimeState {

--- a/Falling/Sources/Feature/Main/Cell/MainCollectionViewItemViewModel.swift
+++ b/Falling/Sources/Feature/Main/Cell/MainCollectionViewItemViewModel.swift
@@ -1,0 +1,132 @@
+//
+//  MainCollectionViewItemViewModel.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/10/06.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+final class MainCollectionViewItemViewModel: ViewModelType {
+  
+  let userDTO: UserDTO
+  
+  init(userDTO: UserDTO) {
+    self.userDTO = userDTO
+  }
+  
+  enum TimeState {
+    case initial(value: Double) // 7~8
+    case five(value: Double)  // 6~7
+    case four(value: Double) // 5~6
+    case three(value: Double) // 4~5
+    case two(value: Double) // 3~4
+    case one(value: Double) // 2~3
+    case zero(value: Double) // 1~2
+    case over(value: Double) // 0~1
+    
+    init(rawValue: Double) {
+      switch rawValue {
+      case 7.0..<8.0:
+        self = .initial(value: rawValue)
+      case 6.0..<7.0:
+        self = .five(value: rawValue)
+      case 5.0..<6.0:
+        self = .four(value: rawValue)
+      case 4.0..<5.0:
+        self = .three(value: rawValue)
+      case 3.0..<4.0:
+        self = .two(value: rawValue)
+      case 2.0..<3.0:
+        self = .one(value: rawValue)
+      case 1.0..<2.0:
+        self = .zero(value: rawValue)
+      default:
+        self = .over(value: rawValue)
+      }
+    }
+    
+    var color: FallingColors {
+      switch self {
+      case .zero, .five:
+        return FallingAsset.Color.primary500
+      case .four:
+        return FallingAsset.Color.thtOrange100
+      case .three:
+        return FallingAsset.Color.thtOrange200
+      case .two:
+        return FallingAsset.Color.thtOrange300
+      case .one:
+        return FallingAsset.Color.thtRed
+      default:
+        return FallingAsset.Color.neutral300
+      }
+    }
+    
+    var isDotHidden: Bool {
+      switch self {
+      case .initial, .over:
+        return true
+      default:
+        return false
+      }
+    }
+    
+    var fillColor: FallingColors {
+      switch self {
+      case .over:
+        return FallingAsset.Color.neutral300
+      default:
+        return FallingAsset.Color.clear
+      }
+    }
+    
+    var getText: String {
+      switch self {
+      case .initial, .over:
+        return String("-")
+      case .five(let value), .four(let value), .three(let value), .two(let value), .one(let value), .zero(let value):
+        return String(Int(value) - 1)
+      }
+    }
+    
+    var getProgress: Double {
+      switch self {
+      case .initial:
+        return 1
+      case .five(let value), .four(let value), .three(let value), .two(let value), .one(let value), .zero(let value), .over(let value):
+        return (value - 2) / 5
+      }
+    }
+  }
+  
+  var disposeBag: DisposeBag = DisposeBag()
+  
+  struct Input {
+    
+  }
+  
+  struct Output {
+    let timeState: Driver<TimeState>
+    let isTimeOver: Driver<Bool>
+  }
+  
+  func transform(input: Input) -> Output {
+    let time = Observable<Int>.interval(.milliseconds(10),
+                                        scheduler: MainScheduler.instance)
+      .take(8 * 100 + 1)
+      .map { round((8 - Double($0) / 100) * 100) / 100 }
+      .asDriver(onErrorDriveWith: Driver<Double>.empty())
+    
+    let timeState = time.map { TimeState(rawValue: $0) }
+    let isTimeOver = time.map { $0 == 0.0 }
+    
+    return Output(
+      timeState: timeState,
+      isTimeOver: isTimeOver
+    )
+  }
+}

--- a/Falling/Sources/Feature/Main/MainView.swift
+++ b/Falling/Sources/Feature/Main/MainView.swift
@@ -19,6 +19,7 @@ final class MainView: TFBaseView {
     let collectionView = UICollectionView(frame: .zero,
                                           collectionViewLayout: flowLayout)
     collectionView.register(cellType: MainCollectionViewCell.self)
+    collectionView.isScrollEnabled = false
     collectionView.backgroundColor = FallingAsset.Color.neutral700.color
     return collectionView
   }()

--- a/Falling/Sources/Feature/Main/MainView.swift
+++ b/Falling/Sources/Feature/Main/MainView.swift
@@ -12,90 +12,25 @@ import SnapKit
 
 final class MainView: TFBaseView {
   
-  lazy var backgroundView: UIView = {
-    let v = UIView()
-    v.layer.cornerRadius = 15
-    v.backgroundColor = FallingAsset.Color.dimColor.color.withAlphaComponent(0.5)
-    return v
+  lazy var collectionView: UICollectionView = {
+    let flowLayout = UICollectionViewFlowLayout()
+    flowLayout.minimumLineSpacing = 14
+    flowLayout.scrollDirection = .vertical
+    let collectionView = UICollectionView(frame: .zero,
+                                          collectionViewLayout: flowLayout)
+    collectionView.register(cellType: MainCollectionViewCell.self)
+    collectionView.backgroundColor = FallingAsset.Color.neutral700.color
+    return collectionView
   }()
   
-  lazy var timerView = CardTimerView()
-  
-  lazy var progressView = CardProgressView()
-  
-  override func layoutSubviews() {
-    self.backgroundColor = .systemGray
-  }
-  
   override func makeUI() {
-    self.addSubview(backgroundView)
+    self.addSubview(collectionView)
     
-    backgroundView.addSubviews([
-      timerView,
-      progressView
-    ])
-    
-    backgroundView.snp.makeConstraints {
-      $0.top.equalTo(self.safeAreaLayoutGuide).inset(12)
-      $0.leading.trailing.equalToSuperview().inset(12)
-      $0.height.equalTo(32)
-    }
-    
-    timerView.snp.makeConstraints {
-      $0.leading.equalToSuperview().inset(9)
-      $0.centerY.equalToSuperview()
-      $0.width.equalTo(22)
-      $0.height.equalTo(22)
-    }
-    
-    progressView.snp.makeConstraints {
-      $0.leading.equalTo(timerView.snp.trailing).offset(9)
-      $0.trailing.equalToSuperview().inset(12)
-      $0.centerY.equalToSuperview()
-      $0.height.equalTo(6)
-    }
-  }
-  
-  func dotPosition(progress: Double, rect: CGRect) -> CGPoint {
-    var progress = progress
-    // progress가 -0.05미만 혹은 1이상은 점(dot)을 0초에 위치시키기 위함
-    let strokeRange: Range<Double> = -0.05..<1
-    if !(strokeRange ~= progress) { progress = 0.95 }
-    let radius = CGFloat(rect.height / 2 - timerView.strokeLayer.lineWidth / 2)
-    let angle = 2 * CGFloat.pi * CGFloat(progress) - CGFloat.pi / 2
-    let dotX = radius * cos(angle + 0.35)
-    let dotY = radius * sin(angle + 0.35)
-    
-    let point = CGPoint(x: dotX, y: dotY)
-    
-    return CGPoint(
-      x: rect.midX + point.x,
-      y: rect.midY + point.y
-    )
-  }
-}
-
-extension Reactive where Base: MainView {
-  var timeState: Binder<MainViewModel.TimeState> {
-    return Binder(self.base) { (base, state) in
-      base.timerView.trackLayer.strokeColor = state.fillColor.color.cgColor
-      base.timerView.strokeLayer.strokeColor = state.color.color.cgColor
-      base.timerView.dotLayer.strokeColor = state.color.color.cgColor
-      base.timerView.dotLayer.fillColor = state.color.color.cgColor
-      base.timerView.timerLabel.textColor = state.color.color
-      base.progressView.progressBarColor = state.color.color
-      
-      base.timerView.dotLayer.isHidden = state.isDotHidden
-      
-      base.timerView.timerLabel.text = state.getText
-      
-      base.progressView.progress = CGFloat(state.getProgress)
-      
-      // TimerView Animation은 소수점 둘째 자리까지 표시해야 오차가 발생하지 않음
-      let strokeEnd = round(CGFloat(state.getProgress) * 100) / 100
-      base.timerView.dotLayer.position = base.dotPosition(progress: strokeEnd, rect: base.timerView.bounds)
-      
-      base.timerView.strokeLayer.strokeEnd = strokeEnd
+    self.collectionView.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(8)
+      $0.leading.equalToSuperview()
+      $0.bottom.equalToSuperview()
+      $0.trailing.equalToSuperview()
     }
   }
 }

--- a/Falling/Sources/Feature/Main/MainViewController.swift
+++ b/Falling/Sources/Feature/Main/MainViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 import RxSwift
 import RxCocoa
 import RxDataSources
-import SwiftUI
 
 final class MainViewController: TFBaseViewController {
   
@@ -113,9 +112,17 @@ extension Reactive where Base: MainViewController {
     return ControlEvent(events: source)
   }
 }
+#if DEBUG
+import SwiftUI
 
 struct MainViewControllerPreView: PreviewProvider {
   static var previews: some View {
-    MainViewController(viewModel: MainViewModel(navigator: MainNavigator(controller: UINavigationController()))).toPreView()
+    let navigator = MainNavigator(controller: UINavigationController())
+
+    let viewModel = MainViewModel(navigator: navigator)
+
+    return MainViewController(viewModel: viewModel)
+      .toPreView()
   }
 }
+#endif

--- a/Falling/Sources/Feature/Main/MainViewModel.swift
+++ b/Falling/Sources/Feature/Main/MainViewModel.swift
@@ -20,7 +20,7 @@ final class MainViewModel: ViewModelType {
   }
   
   struct Output {
-    let userList: Driver<[UserSection]>
+    let userList: Driver<[UserDomain]>
     let currentPage: Driver<Int>
   }
   
@@ -41,7 +41,11 @@ final class MainViewModel: ViewModelType {
                                         UserDTO(userIdx: 2),
                                        ])]
     
-    let userList = Driver.just(userSectionList)
+    let userList = Driver.just([
+      UserDomain(userIdx: 0),
+      UserDomain(userIdx: 1),
+      UserDomain(userIdx: 2),
+    ])
 
     let currentPage = timeOverTrigger.withLatestFrom(currentIndex.asDriver(onErrorJustReturn: 0)) { _, page in
       currentIndex.onNext(page + 1)

--- a/Falling/Sources/Feature/Main/MainViewModel.swift
+++ b/Falling/Sources/Feature/Main/MainViewModel.swift
@@ -100,11 +100,12 @@ final class MainViewModel: ViewModelType {
   var disposeBag: DisposeBag = DisposeBag()
   
   struct Input {
-    
+    let trigger: Driver<Void>
   }
   
   struct Output {
-    let state: Driver<TimeState>
+    let userList: Driver<[UserSection]>
+    let timeState: Driver<TimeState>
   }
   
   init(navigator: MainNavigator) {
@@ -112,16 +113,34 @@ final class MainViewModel: ViewModelType {
   }
   
   func transform(input: Input) -> Output {
+    let listSubject = BehaviorSubject<[UserSection]>(value: [])
+    
+    let userSections = [UserSection(header: "ass",
+                                   items: [
+                                    UserDTO(userIdx: 0),
+                                    UserDTO(userIdx: 1),
+                                    UserDTO(userIdx: 2),
+                                   ])]
+    
+//    let userList = listSubject.onNext(userSections)
+    
+//    let refreshResponse = input.trigger.map {
+//      listSubject.onNext(userSections)
+//    }
+    
+    let userList = Observable.just(userSections).asDriver(onErrorJustReturn: [])
+    
     let time = Observable<Int>.interval(.milliseconds(10),
                                         scheduler: MainScheduler.instance)
       .take(8 * 100 + 1)
       .map { round((8 - Double($0) / 100) * 100) / 100 }
       .asDriver(onErrorDriveWith: Driver<Double>.empty())
     
-    let state = time.map { TimeState(rawValue: $0) }
+    let timeState = time.map { TimeState(rawValue: $0) }
     
     return Output(
-      state: state
+      userList: userList,
+      timeState: timeState
     )
   }
 }

--- a/Falling/Sources/Feature/Main/MainViewModel.swift
+++ b/Falling/Sources/Feature/Main/MainViewModel.swift
@@ -4,6 +4,7 @@
 //
 //  Created by SeungMin on 2023/08/15.
 //
+import Foundation
 
 import RxSwift
 import RxCocoa
@@ -40,16 +41,12 @@ final class MainViewModel: ViewModelType {
                                         UserDTO(userIdx: 2),
                                        ])]
     
-    let userList = Observable.just(userSectionList).asDriver(onErrorJustReturn: [])
-    
-    let currentPage = currentIndex.map{ $0 }.asDriver(onErrorJustReturn: 0)
-    
-    timeOverTrigger.do(onNext: {
-      do {
-        currentIndex.onNext(try currentIndex.value() + 1)
-      } catch { }
-    }).drive()
-      .disposed(by: disposeBag)
+    let userList = Driver.just(userSectionList)
+
+    let currentPage = timeOverTrigger.withLatestFrom(currentIndex.asDriver(onErrorJustReturn: 0)) { _, page in
+      currentIndex.onNext(page + 1)
+      return page + 1
+    }.startWith(0)
     
     return Output(
       userList: userList,

--- a/Falling/Sources/Feature/Main/MainViewModel.swift
+++ b/Falling/Sources/Feature/Main/MainViewModel.swift
@@ -7,105 +7,20 @@
 
 import RxSwift
 import RxCocoa
-import Foundation
 
 final class MainViewModel: ViewModelType {
-  
-  enum TimeState {
-    case initial(value: Double) // 7~8
-    case five(value: Double)  // 6~7
-    case four(value: Double) // 5~6
-    case three(value: Double) // 4~5
-    case two(value: Double) // 3~4
-    case one(value: Double) // 2~3
-    case zero(value: Double) // 1~2
-    case over(value: Double) // 0~1
-    
-    init(rawValue: Double) {
-      switch rawValue {
-      case 7.0..<8.0:
-        self = .initial(value: rawValue)
-      case 6.0..<7.0:
-        self = .five(value: rawValue)
-      case 5.0..<6.0:
-        self = .four(value: rawValue)
-      case 4.0..<5.0:
-        self = .three(value: rawValue)
-      case 3.0..<4.0:
-        self = .two(value: rawValue)
-      case 2.0..<3.0:
-        self = .one(value: rawValue)
-      case 1.0..<2.0:
-        self = .zero(value: rawValue)
-      default:
-        self = .over(value: rawValue)
-      }
-    }
-    
-    var color: FallingColors {
-      switch self {
-      case .zero, .five:
-        return FallingAsset.Color.primary500
-      case .four:
-        return FallingAsset.Color.thtOrange100
-      case .three:
-        return FallingAsset.Color.thtOrange200
-      case .two:
-        return FallingAsset.Color.thtOrange300
-      case .one:
-        return FallingAsset.Color.thtRed
-      default:
-        return FallingAsset.Color.neutral300
-      }
-    }
-    
-    var isDotHidden: Bool {
-      switch self {
-      case .initial, .over:
-        return true
-      default:
-        return false
-      }
-    }
-    
-    var fillColor: FallingColors {
-      switch self {
-      case .over:
-        return FallingAsset.Color.neutral300
-      default:
-        return FallingAsset.Color.clear
-      }
-    }
-    
-    var getText: String {
-      switch self {
-      case .initial, .over:
-        return String("-")
-      case .five(let value), .four(let value), .three(let value), .two(let value), .one(let value), .zero(let value):
-        return String(Int(value) - 1)
-      }
-    }
-    
-    var getProgress: Double {
-      switch self {
-      case .initial:
-        return 1
-      case .five(let value), .four(let value), .three(let value), .two(let value), .one(let value), .zero(let value), .over(let value):
-        return (value - 2) / 5
-      }
-    }
-  }
   
   private let navigator: MainNavigator
   var disposeBag: DisposeBag = DisposeBag()
   
   struct Input {
     let trigger: Driver<Void>
+    let timeOverTrigger: Driver<Void>
   }
   
   struct Output {
     let userList: Driver<[UserSection]>
-    let timeState: Driver<TimeState>
+    let currentPage: Driver<Int>
   }
   
   init(navigator: MainNavigator) {
@@ -114,33 +29,31 @@ final class MainViewModel: ViewModelType {
   
   func transform(input: Input) -> Output {
     let listSubject = BehaviorSubject<[UserSection]>(value: [])
+    let currentIndex = BehaviorSubject<Int>(value: 0)
     
-    let userSections = [UserSection(header: "ass",
-                                   items: [
-                                    UserDTO(userIdx: 0),
-                                    UserDTO(userIdx: 1),
-                                    UserDTO(userIdx: 2),
-                                   ])]
+    let timeOverTrigger = input.timeOverTrigger
     
-//    let userList = listSubject.onNext(userSections)
+    let userSectionList = [UserSection(header: "header",
+                                       items: [
+                                        UserDTO(userIdx: 0),
+                                        UserDTO(userIdx: 1),
+                                        UserDTO(userIdx: 2),
+                                       ])]
     
-//    let refreshResponse = input.trigger.map {
-//      listSubject.onNext(userSections)
-//    }
+    let userList = Observable.just(userSectionList).asDriver(onErrorJustReturn: [])
     
-    let userList = Observable.just(userSections).asDriver(onErrorJustReturn: [])
+    let currentPage = currentIndex.map{ $0 }.asDriver(onErrorJustReturn: 0)
     
-    let time = Observable<Int>.interval(.milliseconds(10),
-                                        scheduler: MainScheduler.instance)
-      .take(8 * 100 + 1)
-      .map { round((8 - Double($0) / 100) * 100) / 100 }
-      .asDriver(onErrorDriveWith: Driver<Double>.empty())
-    
-    let timeState = time.map { TimeState(rawValue: $0) }
+    timeOverTrigger.do(onNext: {
+      do {
+        currentIndex.onNext(try currentIndex.value() + 1)
+      } catch { }
+    }).drive()
+      .disposed(by: disposeBag)
     
     return Output(
       userList: userList,
-      timeState: timeState
+      currentPage: currentPage
     )
   }
 }

--- a/Falling/Sources/Feature/Main/Subviews/CardTimerView.swift
+++ b/Falling/Sources/Feature/Main/Subviews/CardTimerView.swift
@@ -23,6 +23,7 @@ final class CardTimerView: TFBaseView {
     let layer = CAShapeLayer()
     layer.lineWidth = 2
     layer.fillColor = FallingAsset.Color.clear.color.cgColor
+    layer.strokeColor = FallingAsset.Color.neutral300.color.cgColor
     return layer
   }()
   

--- a/Falling/Sources/Feature/Main/Subviews/CardTimerView.swift
+++ b/Falling/Sources/Feature/Main/Subviews/CardTimerView.swift
@@ -10,13 +10,13 @@ import UIKit
 final class CardTimerView: TFBaseView {
   
   lazy var timerLabel: UILabel = {
-    let l = UILabel()
-    l.font = .thtCaption1M
-    l.textAlignment = .center
-    l.backgroundColor = FallingAsset.Color.unSelected.color
-    l.layer.cornerRadius = 16 / 2
-    l.clipsToBounds = true
-    return l
+    let label = UILabel()
+    label.font = .thtCaption1M
+    label.textAlignment = .center
+    label.backgroundColor = FallingAsset.Color.unSelected.color
+    label.layer.cornerRadius = 16 / 2
+    label.clipsToBounds = true
+    return label
   }()
   
   lazy var trackLayer: CAShapeLayer = {

--- a/Falling/Sources/Feature/Main/UserSection.swift
+++ b/Falling/Sources/Feature/Main/UserSection.swift
@@ -1,0 +1,35 @@
+//
+//  UserSection.swift
+//  Falling
+//
+//  Created by SeungMin on 2023/10/06.
+//
+
+import RxDataSources
+
+struct UserSection {
+  var header: String
+  var items: [Item]
+}
+
+extension UserSection: AnimatableSectionModelType {
+  typealias Item = UserDTO
+  var identity: String {
+    return self.header
+  }
+  
+  init(original: UserSection, items: [Item]) {
+    self = original
+    self.items = items
+  }
+}
+
+extension UserDTO: IdentifiableType, Equatable {
+  static func == (lhs: UserDTO, rhs: UserDTO) -> Bool {
+    lhs.identity == rhs.identity
+  }
+
+  var identity: Int {
+    return userIdx
+  }
+}

--- a/Falling/Sources/Feature/Main/UserSection.swift
+++ b/Falling/Sources/Feature/Main/UserSection.swift
@@ -4,8 +4,24 @@
 //
 //  Created by SeungMin on 2023/10/06.
 //
+import Foundation
 
 import RxDataSources
+
+enum MainProfileSection {
+  case profile
+}
+
+struct UserDomain: Hashable {
+  let identifier = UUID()
+  let userIdx: Int
+}
+
+extension UserDTO {
+  func toDomain() -> UserDomain {
+    UserDomain(userIdx: self.userIdx)
+  }
+}
 
 struct UserSection {
   var header: String


### PR DESCRIPTION
## Motivation ⍰

- 현재 보이는 유저 카드 셀에서의 타임이 0이 되면 자동으로 다음 셀로 스크롤 구현하기 위함

<br>

## Key Changes 🔑

미리보기는 다음과 같습니다.

<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/3be01177-4241-409d-bb3a-9939a2faf3cf" width=25%>


현재 보이는 유저 카드 셀에서의 타임이 0이되면 자동으로 다음 셀로 스크롤되고 그 셀의 타이머가 시작됩니다.
유저 카드 컬렉션 뷰의 각 셀에 대해 대한 뷰모델을 만들고 그 뷰모델에서 구독을 생성합니다.
이 때, 구독을 하는 순간부터 타이머가 돌기 때문에 현재 보이는 유저 카드 셀의 타임이 0이 됐을 때 알림을 보내기 위해
샐을 생성할 때 time이 0이 됐을 때의 동작을 delegate에 위임합니다.
그래서 isTimeOver driver의 파라미터가 true가 되면 delegate로 scrollToNext함수를 호출합니다.
delegate를 준수하는 vc에서 scrollToNext를 호출하면 timeOverTrigger event에서 void를 emit하도록 해서
timeOverTrigger가 emit할 때만 해당 셀에 대한 구독을 생성합니다.(bindViewModel)
다음 셀로 넘어가기 위해서 현재의 인덱스를 저장하는 BehaviorSubject 상수를 구독해서 index를 갱신받아서
vc에서 do(onNext:)로 특정 셀의 index 스크롤되도록 구현했습니다.

1. 더 쉽게 구현할 수 있는 방법이 있을 지 궁금합니다.
- viewModel에서 input, output, tranform의 형태를 유지하려다보니 저도 vm에서 구독하게 되는 상황이 나오게 되더군요..

2. 네트워크 에러나 다른 탭으로 넘어갔을 떄 시간을 멈춰야할 거 같은데 Driver는 complete를 하지 않다보니
중지 및 재개를 어떻게 구현할지 좀 고민됩니다.

<br>

## To Reviewers 🙏🏻

- [ ] 현재 보이는 유저 카드 셀의 타이머가 0초가 됐을 때, 다음 셀로 자동으로 넘어가는지 확인해주세요
- [ ] 메모리 누수나 구독이 중복이 생기지 않을 지도 한 번 봐주세요

<br>

## Linked Issue 🔗

- [ ] #35 
