### PR TITLE
[#59]Fix: 타이머가 끝난 후에 다음 유저 카드로 넘어가지 않는 현상 수정

### DIFF
--- a/Projects/Features/Falling/Src/Subviews/Cell/FallinguserCollectionViewCellModel.swift
+++ b/Projects/Features/Falling/Src/Subviews/Cell/FallinguserCollectionViewCellModel.swift
@@ -153,7 +153,7 @@ final class FallinguserCollectionViewCellModel: ViewModelType {
                                           scheduler: MainScheduler.instance)
           .take(Int(startTime * 100) + 1) // 시간의 총 개수
           .map { value in
-            let time = (startTime * 100 - Double(value)) / 100
+            let time = round((startTime * 100 - Double(value))) / 100
             currentTime = time
             return time
           }


### PR DESCRIPTION
## Motivation ⍰

- 간헐적으로 타이머가 끝난 후에 다음 유저 카드로 넘어가지 않는 현상 수정 위함

<br>

## Key Changes 🔑

- 문제 발생 상황은 다음과 같음
<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/a9069606-fe98-478b-8c06-38d497dc9b57" width=40%>

- 이전에 소수점 셋째자리 반올림한 시간을 얻기 위해서 100의 자리에서 소수점 첫째자리 반올림 후, 100으로 나누는 작업을 실행했었는데, 실질적으로 셋째자리가 나오지는 않아서 round 함수를 없앴었음.
- 왜 오차가 발생하고 그 오차가 간헐적으로 발생하는 지는 모르겠음.

```swift
let timer = timerActiveTrigger
      .flatMapLatest { value in
        if !value {
          if currentTime == 0 { currentTime = 8.0 } // 다음 셀로 넘어가도 0이면 자동 스크롤되므로 0초가 되면 다시 8.0으로 갱신
          startTime = currentTime
          return Driver.just(currentTime)
        } else {
          return Observable<Int>.interval(.milliseconds(10),
                                          scheduler: MainScheduler.instance)
          .take(Int(startTime * 100) + 1) // 시간의 총 개수
          .map { value in
            let time = round((startTime * 100 - Double(value))) / 100 // round 함수 추가로 소수점 첫째자리 반올림 후 100으로 나눔
            currentTime = time
            return time
          }
          .debug() // emit되는 시간을 print할 수 있음.
          .asDriver(onErrorDriveWith: Driver<Double>.empty())
        }
      }.asDriver(onErrorJustReturn: 8.0)
```

<br>

## To Reviewers 🙏🏻

- [x] 이전이랑 동일하게 시간이 다 됐을 때, 다음 유저 카드로 넘어가는 지 확인해주세요.

<br>

## Linked Issue 🔗

- [ ] #59 
