### PR TITLE
차단하기 기능 구현

### DIFF
--- a/Projects/Features/Falling/Src/Subviews/PauseView.swift
+++ b/Projects/Features/Falling/Src/Subviews/PauseView.swift
@@ -45,13 +45,6 @@ open class PauseView: TFBaseView {
     return imageView
   }()
   
-  private lazy var labelStackView: UIStackView = {
-    let stackView = UIStackView()
-    stackView.axis = .vertical
-    stackView.spacing = 4
-    return stackView
-  }()
-  
   private lazy var titleLabel: UILabel = {
     let label = UILabel()
     label.font = UIFont.thtP1R
@@ -59,18 +52,9 @@ open class PauseView: TFBaseView {
     label.textColor = DSKitAsset.Color.pauseTitle.color
     label.numberOfLines = 2
     label.setTextWithLineHeight(
-      text: "대화가 잘 통하는 무디를\n찾을 준비가 됐나요?",
-      lineHeight: 19.8
+      text: "무디 탐색을 일시정지했어요.\n다시 무디를 보고싶다면 더블 탭해주세요.",
+      lineHeight: 19.6
     )
-    return label
-  }()
-  
-  private lazy var resumeLabel: UILabel = {
-    let label = UILabel()
-    label.text = "더블탭으로 다시 시작하기"
-    label.font = UIFont.thtP1M
-    label.textAlignment = .center
-    label.textColor = DSKitAsset.Color.neutral50.color
     return label
   }()
     
@@ -79,11 +63,10 @@ open class PauseView: TFBaseView {
     
     self.addSubview(blurView)
     self.blurView.contentView.addSubview(stackView)
-    self.blurView.contentView.addSubview(resumeLabel)
     
     stackView.addArrangedSubviews([
       pauseView,
-      labelStackView
+      titleLabel
     ])
     
     pauseView.snp.makeConstraints {
@@ -95,16 +78,7 @@ open class PauseView: TFBaseView {
     pauseImageView.snp.makeConstraints {
       $0.centerX.centerY.equalToSuperview()
     }
-    
-    resumeLabel.snp.makeConstraints {
-      $0.centerX.equalToSuperview()
-      $0.bottom.equalToSuperview().inset(20)
-    }
-    
-    labelStackView.addArrangedSubviews([
-      titleLabel
-    ])
-    
+      
     stackView.snp.makeConstraints {
       $0.centerX.centerY.equalToSuperview()
     }

--- a/Projects/Modules/DesignSystem/Resources/Color.xcassets/DimColor/Default.colorset/Contents.json
+++ b/Projects/Modules/DesignSystem/Resources/Color.xcassets/DimColor/Default.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.500",
-          "blue" : "0x00",
-          "green" : "0x00",
-          "red" : "0x00"
+          "alpha" : "0.600",
+          "blue" : "0x11",
+          "green" : "0x11",
+          "red" : "0x11"
         }
       },
       "idiom" : "universal"

--- a/Projects/Modules/DesignSystem/Resources/Color.xcassets/DimColor/PauseDim.colorset/Contents.json
+++ b/Projects/Modules/DesignSystem/Resources/Color.xcassets/DimColor/PauseDim.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.550",
-          "blue" : "0x10",
-          "green" : "0x10",
-          "red" : "0x10"
+          "alpha" : "0.200",
+          "blue" : "0x11",
+          "green" : "0x11",
+          "red" : "0x11"
         }
       },
       "idiom" : "universal"

--- a/Projects/Modules/DesignSystem/Src/UIComponent/TFAlertViewController.swift
+++ b/Projects/Modules/DesignSystem/Src/UIComponent/TFAlertViewController.swift
@@ -1,0 +1,241 @@
+//
+//  TFAlertViewController.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/3/24.
+//
+
+import UIKit
+
+public enum ReportAction {
+  case complaints, block, withdraw
+  
+  var title: String {
+    switch self {
+    case .complaints:
+      return "차단할까요?"
+    case .block:
+      return "어떤 문제가 있나요?"
+    case .withdraw:
+      return "계정 탈퇴하기"
+    }
+  }
+  
+  var message: String? {
+    switch self {
+    case .block:
+      return "해당 사용자와 서로 차단됩니다."
+    case .withdraw:
+      return "정말 탈퇴하시겠어요? 회원님의 모든 정보 및\n사용 내역은 복구 불가합니다. 블링 환불 관련 문의는\nteamtht23@gmail.com 으로 부탁드립니다."
+    default:
+      return nil
+    }
+  }
+  
+  var leftActionTitle: String {
+    switch self {
+    case .complaints:
+      return "차단할까요?"
+    case .block:
+      return "차단하기"
+    case .withdraw:
+      return "탈퇴하기"
+    }
+  }
+  
+  var rightActionTitle: String {
+    switch self {
+    default:
+      return "취소"
+    }
+  }
+}
+
+public final class TFAlertViewController: TFBaseViewController {
+  private var titleText: String?
+  private var messageText: String?
+  private var contentView: UIView?
+  
+  private lazy var dimView: UIView = {
+    let view = UIView()
+    view.backgroundColor = DSKitAsset.Color.DimColor.default.color
+    return view
+  }()
+  
+  private lazy var containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .center
+    stackView.backgroundColor = DSKitAsset.Color.neutral600.color
+    stackView.layer.cornerRadius = 8
+    stackView.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
+    stackView.layoutMargins = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    return stackView
+  }()
+  
+  private lazy var labelStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 6
+    stackView.alignment = .center
+    return stackView
+  }()
+  
+  private lazy var buttonStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 16.0
+    stackView.alignment = .center
+    return stackView
+  }()
+  
+  private lazy var titleLabel: UILabel? = {
+    guard titleText != nil else { return nil }
+    
+    let label = UILabel()
+    label.text = titleText
+    label.font = UIFont.thtH5Sb
+    label.textAlignment = .center
+    label.textColor = DSKitAsset.Color.neutral50.color
+    label.numberOfLines = 0
+    return label
+  }()
+  
+  private lazy var messageLabel: UILabel? = {
+    guard messageText != nil else { return nil }
+    
+    let label = UILabel()
+    label.text = messageText
+    label.font = UIFont.thtP1R
+    label.textAlignment = .center
+    label.textColor = DSKitAsset.Color.neutral300.color
+    label.numberOfLines = 0
+    return label
+  }()
+  
+  let separatorView: UIView = {
+    let view = UIView()
+    view.backgroundColor = DSKitAsset.Color.neutral400.color
+    return view
+  }()
+  
+  init(
+    titleText: String? = nil,
+    messageText: String? = nil
+  ) {
+    super.init(nibName: nil, bundle: nil)
+    self.titleText = titleText
+    self.messageText = messageText
+    
+    modalPresentationStyle = .overFullScreen
+  }
+  
+  convenience init(contentView: UIView) {
+    self.init()
+    
+    self.contentView = contentView
+    modalPresentationStyle = .overFullScreen
+  }
+  
+  required public init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    
+    // curveEaseOut: 시작은 천천히, 끝날 땐 빠르게
+    UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveEaseOut) { [weak self] in
+      self?.containerStackView.transform = .identity
+      self?.containerStackView.isHidden = false
+    }
+  }
+  
+  public override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    
+    // curveEaseIn: 시작은 빠르게, 끝날 땐 천천히
+    UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveEaseIn) { [weak self] in
+      self?.containerStackView.transform = .identity
+      self?.containerStackView.isHidden = true
+    }
+  }
+  
+  public override func makeUI() {
+    view.addSubviews([dimView, containerStackView])
+    containerStackView.addArrangedSubviews([labelStackView, buttonStackView])
+    
+    dimView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    containerStackView.snp.makeConstraints {
+      $0.centerY.equalToSuperview()
+      $0.leading.trailing.equalToSuperview().inset(28)
+    }
+    
+    labelStackView.snp.makeConstraints {
+      $0.width.equalToSuperview()
+    }
+    
+    buttonStackView.snp.makeConstraints {
+      $0.width.equalToSuperview()
+    }
+    
+    if let titleLabel = titleLabel {
+      labelStackView.addArrangedSubview(titleLabel)
+      
+    }
+    
+    if let messageLabel = messageLabel {
+      labelStackView.addArrangedSubview(messageLabel)
+    }
+    
+    if !labelStackView.subviews.isEmpty {
+      containerStackView.setCustomSpacing(20, after: labelStackView)
+    }
+    
+    separatorView.snp.makeConstraints {
+      $0.width.equalToSuperview()
+      $0.height.equalTo(1.5)
+    }
+  }
+  
+  public func addActionToButton(
+    title: String? = nil,
+    completion: (() -> Void)? = nil
+  ) {
+    guard let title = title else { return }
+    
+    let button = UIButton()
+    button.titleLabel?.font = UIFont.thtSubTitle2Sb
+    
+    // enable
+    button.setTitle(title, for: .normal)
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .normal)
+    button.setBackgroundImage(DSKitAsset.Color.neutral600.color.image(), for: .normal)
+    
+    // disable
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .disabled)
+    button.setBackgroundImage(DSKitAsset.Color.neutral300.color.image(), for: .disabled)
+    
+    button.addAction(for: .touchUpInside) { _ in
+      completion?()
+    }
+    
+    if let _ = buttonStackView.subviews.first {
+      buttonStackView.addArrangedSubview(separatorView)
+    }
+    
+    buttonStackView.addArrangedSubview(button)
+    button.snp.makeConstraints { $0.width.equalToSuperview() }
+  }
+  
+  public func addActionToDim(completion: (() -> Void)? = nil) {
+    let tapGestureRecognizer = UITapGestureRecognizer()
+    tapGestureRecognizer.addAction(closure: { _ in completion?() })
+    
+    dimView.addGestureRecognizer(tapGestureRecognizer)
+  }
+}

--- a/Projects/Modules/DesignSystem/Src/Util/UIColor+Util.swift
+++ b/Projects/Modules/DesignSystem/Src/Util/UIColor+Util.swift
@@ -1,0 +1,18 @@
+//
+//  UIColor+Util.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/20/24.
+//
+
+import UIKit
+
+extension UIColor {
+  /// Convert color to image
+  func image(_ size: CGSize = CGSize(width: 1, height: 1)) -> UIImage {
+    return UIGraphicsImageRenderer(size: size).image { rendererContext in
+      self.setFill()
+      rendererContext.fill(CGRect(origin: .zero, size: size))
+    }
+  }
+}

--- a/Projects/Modules/DesignSystem/Src/Util/UIControl+Util.swift
+++ b/Projects/Modules/DesignSystem/Src/Util/UIControl+Util.swift
@@ -1,0 +1,45 @@
+//
+//  UIControl+Util.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/20/24.
+//
+
+import UIKit
+
+extension UIControl {
+  public typealias UIControlTargetClosure = (UIControl) -> ()
+  
+  private class UIControlClosureWrapper: NSObject {
+    let closure: UIControlTargetClosure
+    init(_ closure: @escaping UIControlTargetClosure) {
+      self.closure = closure
+    }
+  }
+  
+  private struct AssociatedKeys {
+    static var targetClosure = "targetClosure"
+  }
+  
+  private var targetClosure: UIControlTargetClosure? {
+    get {
+      guard let closureWrapper = objc_getAssociatedObject(self, &AssociatedKeys.targetClosure) as? UIControlClosureWrapper else { return nil }
+      return closureWrapper.closure
+      
+    } set(newValue) {
+      guard let newValue = newValue else { return }
+      objc_setAssociatedObject(self, &AssociatedKeys.targetClosure, UIControlClosureWrapper(newValue),
+                               objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+  }
+  
+  @objc func closureAction() {
+    guard let targetClosure = targetClosure else { return }
+    targetClosure(self)
+  }
+  
+  public func addAction(for event: UIControl.Event, closure: @escaping UIControlTargetClosure) {
+    targetClosure = closure
+    addTarget(self, action: #selector(UIControl.closureAction), for: event)
+  }
+}

--- a/Projects/Modules/DesignSystem/Src/Util/UITapGestureRecognizer.swift
+++ b/Projects/Modules/DesignSystem/Src/Util/UITapGestureRecognizer.swift
@@ -1,0 +1,51 @@
+//
+//  UITapGestureRecognizer.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/20/24.
+//
+
+import UIKit
+
+extension UITapGestureRecognizer {
+  public typealias UITapGestureTargetClosure = (UITapGestureRecognizer) -> ()
+  
+  private class UITapGestureClosureWrapper: NSObject {
+    let closure: UITapGestureTargetClosure
+    init(_ closure: @escaping UITapGestureTargetClosure) {
+      self.closure = closure
+    }
+  }
+  
+  private struct AssociatedKeys {
+    static var targetClosure = "targetClosure"
+  }
+  
+  private var targetClosure: UITapGestureTargetClosure? {
+    get {
+      guard let closureWrapper = objc_getAssociatedObject(
+        self, 
+        &AssociatedKeys.targetClosure
+      ) as? UITapGestureClosureWrapper else { return nil }
+      return closureWrapper.closure
+      
+    } set(newValue) {
+      guard let newValue = newValue else { return }
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.targetClosure,
+        UITapGestureClosureWrapper(newValue),
+        objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+  }
+  
+  @objc func closureAction() {
+    guard let targetClosure = targetClosure else { return }
+    targetClosure(self)
+  }
+  
+  public func addAction(closure: @escaping UITapGestureTargetClosure) {
+    targetClosure = closure
+    addTarget(self, action: #selector(UITapGestureRecognizer.closureAction))
+  }
+}

--- a/Projects/Modules/DesignSystem/Src/Util/UIVIewControler+Utils.swift
+++ b/Projects/Modules/DesignSystem/Src/Util/UIVIewControler+Utils.swift
@@ -1,0 +1,82 @@
+//
+//  UIVIewControler+Utils.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/17/24.
+//
+
+import UIKit
+
+extension UIViewController {
+  public func showAlert(title: String? = nil,
+                        message: String? = nil,
+                        attributedMessage: NSAttributedString? = nil,
+                        leftActionTitle: String? = "확인",
+                        rightActionTitle: String = "취소",
+                        leftActionCompletion: (() -> Void)? = nil,
+                        rightActionCompletion: (() -> Void)? = nil,
+                        dimActionCompletion: (() -> Void)? = nil) {
+    let alertViewController = TFAlertViewController(titleText: title,
+                                                    messageText: message)
+    showAlert(alertViewController: alertViewController,
+              leftActionTitle: leftActionTitle,
+              rightActionTitle: rightActionTitle,
+              leftActionCompletion: leftActionCompletion,
+              rightActionCompletion: rightActionCompletion,
+              dimActionCompletion: dimActionCompletion)
+  }
+  
+  public func showAlert(contentView: UIView,
+                        leftActionTitle: String? = "확인",
+                        rightActionTitle: String = "취소",
+                        leftActionCompletion: (() -> Void)? = nil,
+                        rightActionCompletion: (() -> Void)? = nil,
+                        dimActionCompletion: (() -> Void)? = nil) {
+    let alertViewController = TFAlertViewController(contentView: contentView)
+    
+    showAlert(alertViewController: alertViewController,
+              leftActionTitle: leftActionTitle,
+              rightActionTitle: rightActionTitle,
+              leftActionCompletion: leftActionCompletion,
+              rightActionCompletion: rightActionCompletion,
+              dimActionCompletion: dimActionCompletion)
+  }
+  
+  public func showAlert(action: ReportAction,
+                        leftActionCompletion: (() -> Void)? = nil,
+                        rightActionCompletion: (() -> Void)? = nil,
+                        dimActionCompletion: (() -> Void)? = nil) {
+    let alertViewController = TFAlertViewController(
+      titleText: action.title,
+      messageText: action.message
+    )
+    
+    showAlert(alertViewController: alertViewController,
+              leftActionTitle: action.leftActionTitle,
+              rightActionTitle: action.rightActionTitle,
+              leftActionCompletion: leftActionCompletion,
+              rightActionCompletion: rightActionCompletion,
+              dimActionCompletion: dimActionCompletion)
+  }
+  
+  private func showAlert(alertViewController: TFAlertViewController,
+                         leftActionTitle: String?,
+                         rightActionTitle: String,
+                         leftActionCompletion: (() -> Void)?,
+                         rightActionCompletion: (() -> Void)?,
+                         dimActionCompletion: (() -> Void)?) {
+    alertViewController.addActionToButton(title: leftActionTitle) {
+      alertViewController.dismiss(animated: false, completion: leftActionCompletion)
+    }
+    
+    alertViewController.addActionToButton(title: rightActionTitle) {
+      alertViewController.dismiss(animated: false, completion: rightActionCompletion)
+    }
+    
+    alertViewController.addActionToDim() {
+      alertViewController.dismiss(animated: false, completion: dimActionCompletion)
+    }
+    
+    present(alertViewController, animated: false, completion: nil)
+  }
+}


### PR DESCRIPTION
## Motivation ⍰

- report 버튼 클릭 시, 경고창을 표시하고, 차단하면 다음 셀로 애니메이션이 적용되면서 넘어가도록 구현

<br>

## Key Changes 🔑

미리보기는 다음과 같습니다.

<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/278489ed-cd66-4eda-b511-cfbfb69fd7e7" width=25%>

1. AlertController 클래스 커스텀
- title, message, contentView, 왼쪽, 오른쪽, dim action 추가 함수 구현

2. TimerActiveAction 추가 -> 멈추는 이벤트에 따라 케이스를 나눔
- 프로필 더블 클릭, 다른 탭으로 이동 -> PauseView 표시하고 타이머 정지
- report 버튼, dimView 클릭 -> PauseView 표시 안 하고 타이머 정지

3. 차단하기 버튼 클릭 시, 다음 유저로 넘어가는 애니메이션 구현
- 현재는 차단하기를 했을 떄, 데이터 또는 dataSource에서 item을 삭제하지 않고, 0.5초 후에 scroll하는 방식으로 구현
- dimview를 클릭하면 타이머가 다시 시작되도록 이벤트 전달
- reject 버튼 이벤트는 애니메이션 1초여서 1초후에 다음 유저로 넘어가도록 구현

item delete를 해서 다음 유저로 넘어가게 하고 싶은데 삭제될 아이템의 구독이 해제되지 않거나
indexPath가 1:다 로 되는 문제가 있는데 이 부분은 피드백 주시면 감사합니다.

AlertController를 커스텀했는데, 버튼이 하나 있을 때와 두 개일 때의 separatorView를 어떻게 설정하면 좋을 지 모르겠습니다.
또한, 신고하기에서 여러 버튼이 있는데 content View에 담아서 전달하는 방식으로 생각하고 있기는한데 이 부분도 어떻게 처리하면 좋을 지 피드백 주시면 감사하겠습니다.

<br>

## To Reviewers 🙏🏻

- [ ] report 버튼 클릭 시, 신고하기 > `차단하기` 혹은 `취소` 혹은 `dimView 클릭`이 잘 동작하는 지 확인해주세요
- [ ] 신고하기 클릭 시, 다음 유저로 넘어가는 애니메이션이 잘 적용되는지 확인해주세요.

<br>

## Linked Issue 🔗

- [ ] #74 
