### PR TITLE
Feature/complaints UI

### DIFF
--- a/Projects/Features/Falling/Src/Home/FallingHomeViewController.swift
+++ b/Projects/Features/Falling/Src/Home/FallingHomeViewController.swift
@@ -17,20 +17,6 @@ enum FallingCellButtonAction {
   case like(IndexPath)
 }
 
-enum TimerActiveAction {
-  case viewWillDisAppear(Bool)
-  case profileDoubleTap(Bool)
-  case reportButtonTap(Bool)
-  case DimViewTap(Bool)
-  
-  var state: Bool {
-    switch self {
-    case .viewWillDisAppear(let flag), .profileDoubleTap(let flag), .reportButtonTap(let flag), .DimViewTap(let flag):
-      return flag
-    }
-  }
-}
-
 enum AnimationAction {
   case scroll, delete
 }
@@ -39,6 +25,8 @@ final class FallingHomeViewController: TFBaseViewController {
   private let viewModel: FallingHomeViewModel
   private var dataSource: DataSource!
   private lazy var homeView = FallingHomeView()
+  
+  private lazy var alertContentView = TFAlertContentView()
   
   init(viewModel: FallingHomeViewModel) {
     self.viewModel = viewModel
@@ -74,15 +62,15 @@ final class FallingHomeViewController: TFBaseViewController {
     let fallingCellButtonAction = PublishSubject<FallingCellButtonAction>()
     
     let viewWillDisAppearTrigger = self.rx.viewWillDisAppear.map { _ in
-      return TimerActiveAction.viewWillDisAppear(false)
+      return false
     }.asDriverOnErrorJustEmpty()
     
-    let timerActiveRelay = BehaviorRelay<TimerActiveAction>(value: .profileDoubleTap(true))
+    let timerActiveRelay = BehaviorRelay<Bool>(value: true)
     
     let profileDoubleTapTriggerObserver = PublishSubject<Void>()
     let profileDoubleTapTrigger = profileDoubleTapTriggerObserver
       .withLatestFrom(timerActiveRelay) {
-        return TimerActiveAction.profileDoubleTap(!$1.state)
+        return !$1
       }
       .asDriverOnErrorJustEmpty()
     
@@ -90,7 +78,7 @@ final class FallingHomeViewController: TFBaseViewController {
     
     let reportButtonTapTrigger = reportButtonTapTriggerObserver
       .withLatestFrom(timerActiveRelay) { _, _ in 
-        return TimerActiveAction.reportButtonTap(false)
+        return false
       }
       .asDriverOnErrorJustEmpty()
     
@@ -100,6 +88,8 @@ final class FallingHomeViewController: TFBaseViewController {
     
     let complaintsButtonTapTrigger = PublishRelay<Void>()
     let blockButtonTapTrigger = PublishRelay<Void>()
+    
+    let deleteCellTrigger = Driver.merge(complaintsButtonTapTrigger.asDriverOnErrorJustEmpty(), blockButtonTapTrigger.asDriverOnErrorJustEmpty())
     
     let input = FallingHomeViewModel.Input(
       initialTrigger: initialTrigger,
@@ -125,7 +115,8 @@ final class FallingHomeViewController: TFBaseViewController {
         timeOverSubject: timeOverSubject,
         profileDoubleTapTriggerObserver: profileDoubleTapTriggerObserver,
         fallingCellButtonAction: fallingCellButtonAction,
-        reportButtonTapTriggerObserver: reportButtonTapTriggerObserver
+        reportButtonTapTriggerObserver: reportButtonTapTriggerObserver,
+        deleteCellTrigger: deleteCellTrigger
       )
     }
     
@@ -186,28 +177,51 @@ final class FallingHomeViewController: TFBaseViewController {
       }
       .disposed(by: disposeBag)
     
+    Driver.merge(
+      alertContentView.unpleasantPhotoButton.rx.tap.asDriver(),
+      alertContentView.fakeProfileButton.rx.tap.asDriver(),
+      alertContentView.photoTheftButton.rx.tap.asDriver(),
+      alertContentView.profanityButton.rx.tap.asDriver(),
+      alertContentView.sharingIllegalFootageButton.rx.tap.asDriver())
+    .do { _ in
+      complaintsButtonTapTrigger.accept(())
+      
+      self.homeView.makeToast("신고하기가 완료되었습니다. 해당 사용자와\n서로 차단되며, 신고 사유는 검토 후 처리됩니다.", duration: 3.0, position: .bottom)
+      
+      UIWindow.keyWindow?.rootViewController?.dismiss(animated: false)
+    }
+    .drive()
+    .disposed(by: disposeBag)
+    
     reportButtonTapTriggerObserver.asDriverOnErrorJustEmpty()
       .do { _ in
         self.showAlert(
-          leftActionTitle: "신고하기",
-          rightActionTitle: "차단하기",
-          leftActionCompletion: {
-            self.showAlert(action: .complaints)
-          },
-          rightActionCompletion: {
+          topActionTitle: "신고하기",
+          bottomActionTitle: "차단하기",
+          dimColor: DSKitAsset.Color.clear.color,
+          topActionCompletion: {
             self.showAlert(
-              action: .block,
-              leftActionCompletion: {
-                blockButtonTapTrigger.accept(())
-              },
-              rightActionCompletion: {
-                timerActiveRelay.accept(.DimViewTap(true))
-              }
+              contentView: self.alertContentView,
+              topActionTitle: nil,
+              dimColor: DSKitAsset.Color.clear.color,
+              bottomActionCompletion: { timerActiveRelay.accept(true) },
+              dimActionCompletion: { timerActiveRelay.accept(true) }
             )
           },
-          dimActionCompletion: {
-            timerActiveRelay.accept(.DimViewTap(true))
-          }
+          bottomActionCompletion: {
+            self.showAlert(
+              action: .block,
+              dimColor: DSKitAsset.Color.clear.color,
+              topActionCompletion: {
+                blockButtonTapTrigger.accept(())
+                
+                self.homeView.makeToast("차단하기가 완료되었습니다. 해당 사용자와\n서로 차단되며 설정에서 확인 가능합니다.", duration: 3.0, position: .bottom)
+              },
+              bottomActionCompletion: { timerActiveRelay.accept(true) },
+              dimActionCompletion: { timerActiveRelay.accept(true) }
+            )
+          },
+          dimActionCompletion: { timerActiveRelay.accept(true) }
         )
       }
       .drive()
@@ -215,16 +229,14 @@ final class FallingHomeViewController: TFBaseViewController {
     
     Driver.merge(output.complaintsAction, output.blockAction)
       .do { indexPath in
-//        timerActiveRelay.accept(.DimViewTap(true))
+        guard let _ = self.homeView.collectionView.cellForItem(at: indexPath) as? FallingUserCollectionViewCell else { return }
+        
         self.deleteItems(indexPath)
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
           timeOverSubject.onNext(.delete)
-          timerActiveRelay.accept(.DimViewTap(true))
+          timerActiveRelay.accept(true)
         }
-        
-//        timerActiveRelay.accept(.DimViewTap(true))
-        
-        
       }
       .drive()
       .disposed(by: disposeBag)

--- a/Projects/Features/Falling/Src/Subviews/Cell/ProfileCollectionViewCell.swift
+++ b/Projects/Features/Falling/Src/Subviews/Cell/ProfileCollectionViewCell.swift
@@ -47,6 +47,7 @@ final class ProfileCollectionViewCell: UICollectionViewCell {
       return
     }
     
-    self.imageView.kf.setImage(with: url)
+//    self.imageView.kf.setImage(with: url)
+    self.imageView.image = DSKitAsset.Image.Test.test3.image
   }
 }

--- a/Projects/Features/Falling/Src/Subviews/PauseView.swift
+++ b/Projects/Features/Falling/Src/Subviews/PauseView.swift
@@ -32,7 +32,7 @@ open class PauseView: TFBaseView {
     return stackView
   }()
   
-  private lazy var pauseView: UIView = {
+  lazy var ImageContainerView: UIView = {
     let view = UIView()
     view.backgroundColor = DSKitAsset.Color.DimColor.pauseDim.color
     view.layer.cornerRadius = 31
@@ -45,7 +45,7 @@ open class PauseView: TFBaseView {
     return imageView
   }()
   
-  private lazy var titleLabel: UILabel = {
+  lazy var titleLabel: UILabel = {
     let label = UILabel()
     label.font = UIFont.thtP1R
     label.textAlignment = .center
@@ -65,15 +65,15 @@ open class PauseView: TFBaseView {
     self.blurView.contentView.addSubview(stackView)
     
     stackView.addArrangedSubviews([
-      pauseView,
+      ImageContainerView,
       titleLabel
     ])
     
-    pauseView.snp.makeConstraints {
+    ImageContainerView.addSubview(pauseImageView)
+    
+    ImageContainerView.snp.makeConstraints {
       $0.width.height.equalTo(62)
     }
-    
-    pauseView.addSubview(pauseImageView)
     
     pauseImageView.snp.makeConstraints {
       $0.centerX.centerY.equalToSuperview()

--- a/Projects/Modules/DesignSystem/Src/UIComponent/TFAlertContentView.swift
+++ b/Projects/Modules/DesignSystem/Src/UIComponent/TFAlertContentView.swift
@@ -1,0 +1,100 @@
+//
+//  TFAlertContentView.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/29/24.
+//
+
+import UIKit
+
+public final class TFAlertContentView: TFBaseView {
+  private lazy var stackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 24
+    return stackView
+  }()
+  
+  lazy var titleLabel: UILabel = {
+    let label = UILabel()
+    label.text = "어떤 문제가 있나요?"
+    label.font = UIFont.thtH5Sb
+    label.textAlignment = .center
+    label.textColor = DSKitAsset.Color.neutral50.color
+    label.numberOfLines = 0
+    return label
+  }()
+  
+  let buttonStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 20
+    return stackView
+  }()
+  
+  public let unpleasantPhotoButton: UIButton = {
+    let button = UIButton()
+    button.titleLabel?.font = UIFont.thtSubTitle2R
+    button.setTitle("불괘한 사진", for: .normal)
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .normal)
+    button.setBackgroundColor(DSKitAsset.Color.neutral600.color, for: .normal)
+    return button
+  }()
+  
+  public let fakeProfileButton: UIButton = {
+    let button = UIButton()
+    button.titleLabel?.font = UIFont.thtSubTitle2R
+    button.setTitle("허위 프로필", for: .normal)
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .normal)
+    button.setBackgroundColor(DSKitAsset.Color.neutral600.color, for: .normal)
+    return button
+  }()
+  
+  public let photoTheftButton: UIButton = {
+    let button = UIButton()
+    button.titleLabel?.font = UIFont.thtSubTitle2R
+    button.setTitle("사진 도용", for: .normal)
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .normal)
+    button.setBackgroundColor(DSKitAsset.Color.neutral600.color, for: .normal)
+    return button
+  }()
+  
+  public let profanityButton: UIButton = {
+    let button = UIButton()
+    button.titleLabel?.font = UIFont.thtSubTitle2R
+    button.setTitle("욕설 및 비방", for: .normal)
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .normal)
+    button.setBackgroundColor(DSKitAsset.Color.neutral600.color, for: .normal)
+    return button
+  }()
+  
+  public let sharingIllegalFootageButton: UIButton = {
+    let button = UIButton()
+    button.titleLabel?.font = UIFont.thtSubTitle2R
+    button.setTitle("불법 촬영물 공유", for: .normal)
+    button.setTitleColor(DSKitAsset.Color.neutral50.color, for: .normal)
+    button.setBackgroundColor(DSKitAsset.Color.neutral600.color, for: .normal)
+    return button
+  }()
+  
+  public override func makeUI() {
+    addSubview(stackView)
+    stackView.addArrangedSubviews([titleLabel, buttonStackView])
+    
+    stackView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    buttonStackView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+    }
+    
+    buttonStackView.addArrangedSubviews([
+      unpleasantPhotoButton,
+      fakeProfileButton,
+      photoTheftButton,
+      profanityButton,
+      sharingIllegalFootageButton
+    ])
+  }
+}

--- a/Projects/Modules/DesignSystem/Src/UIComponent/TFAlertViewController.swift
+++ b/Projects/Modules/DesignSystem/Src/UIComponent/TFAlertViewController.swift
@@ -13,9 +13,9 @@ public enum ReportAction {
   var title: String {
     switch self {
     case .complaints:
-      return "차단할까요?"
-    case .block:
       return "어떤 문제가 있나요?"
+    case .block:
+      return "차단할까요?"
     case .withdraw:
       return "계정 탈퇴하기"
     }
@@ -32,7 +32,7 @@ public enum ReportAction {
     }
   }
   
-  var leftActionTitle: String {
+  var topActionTitle: String {
     switch self {
     case .complaints:
       return "차단할까요?"
@@ -43,7 +43,7 @@ public enum ReportAction {
     }
   }
   
-  var rightActionTitle: String {
+  var bottomActionTitle: String {
     switch self {
     default:
       return "취소"
@@ -122,19 +122,21 @@ public final class TFAlertViewController: TFBaseViewController {
   
   init(
     titleText: String? = nil,
-    messageText: String? = nil
+    messageText: String? = nil,
+    dimColor: UIColor = DSKitAsset.Color.DimColor.default.color
   ) {
     super.init(nibName: nil, bundle: nil)
     self.titleText = titleText
     self.messageText = messageText
-    
+    self.dimView.backgroundColor = dimColor
     modalPresentationStyle = .overFullScreen
   }
   
-  convenience init(contentView: UIView) {
+  convenience init(contentView: UIView, dimColor: UIColor) {
     self.init()
     
     self.contentView = contentView
+    self.dimView.backgroundColor = dimColor
     modalPresentationStyle = .overFullScreen
   }
   
@@ -164,7 +166,32 @@ public final class TFAlertViewController: TFBaseViewController {
   
   public override func makeUI() {
     view.addSubviews([dimView, containerStackView])
-    containerStackView.addArrangedSubviews([labelStackView, buttonStackView])
+    
+    if let contentView = contentView {
+      containerStackView.addArrangedSubview(contentView)
+      contentView.snp.makeConstraints {
+        $0.leading.trailing.equalToSuperview()
+      }
+    }
+    
+    if let titleLabel = titleLabel {
+      labelStackView.addArrangedSubview(titleLabel)
+      
+      containerStackView.addArrangedSubview(labelStackView)
+      labelStackView.snp.makeConstraints {
+        $0.width.equalToSuperview()
+      }
+      
+      if let messageLabel = messageLabel {
+        labelStackView.addArrangedSubview(messageLabel)
+      }
+    }
+    
+    if let lastView = containerStackView.subviews.last {
+      containerStackView.setCustomSpacing(20, after: lastView)
+    }
+    
+    containerStackView.addArrangedSubview(buttonStackView)
     
     dimView.snp.makeConstraints {
       $0.edges.equalToSuperview()
@@ -175,25 +202,8 @@ public final class TFAlertViewController: TFBaseViewController {
       $0.leading.trailing.equalToSuperview().inset(28)
     }
     
-    labelStackView.snp.makeConstraints {
-      $0.width.equalToSuperview()
-    }
-    
     buttonStackView.snp.makeConstraints {
       $0.width.equalToSuperview()
-    }
-    
-    if let titleLabel = titleLabel {
-      labelStackView.addArrangedSubview(titleLabel)
-      
-    }
-    
-    if let messageLabel = messageLabel {
-      labelStackView.addArrangedSubview(messageLabel)
-    }
-    
-    if !labelStackView.subviews.isEmpty {
-      containerStackView.setCustomSpacing(20, after: labelStackView)
     }
     
     separatorView.snp.makeConstraints {
@@ -204,10 +214,11 @@ public final class TFAlertViewController: TFBaseViewController {
   
   public func addActionToButton(
     title: String? = nil,
+    withSeparator: Bool = false,
     completion: (() -> Void)? = nil
   ) {
     guard let title = title else { return }
-    
+  
     let button = UIButton()
     button.titleLabel?.font = UIFont.thtSubTitle2Sb
     
@@ -224,12 +235,13 @@ public final class TFAlertViewController: TFBaseViewController {
       completion?()
     }
     
-    if let _ = buttonStackView.subviews.first {
-      buttonStackView.addArrangedSubview(separatorView)
-    }
+    if withSeparator { buttonStackView.addArrangedSubview(separatorView) }
     
     buttonStackView.addArrangedSubview(button)
-    button.snp.makeConstraints { $0.width.equalToSuperview() }
+    button.snp.makeConstraints {
+      $0.width.equalToSuperview()
+      $0.height.equalTo(21)
+    }
   }
   
   public func addActionToDim(completion: (() -> Void)? = nil) {

--- a/Projects/Modules/DesignSystem/Src/UIComponent/TFToast.swift
+++ b/Projects/Modules/DesignSystem/Src/UIComponent/TFToast.swift
@@ -1,0 +1,787 @@
+//
+//  TFToast.swift
+//  DSKit
+//
+//  Created by SeungMin on 4/29/24.
+//
+
+import UIKit
+import ObjectiveC
+
+/**
+ Toast is a Swift extension that adds toast notifications to the `UIView` object class.
+ It is intended to be simple, lightweight, and easy to use. Most toast notifications
+ can be triggered with a single line of code.
+ 
+ The `makeToast` methods create a new view and then display it as toast.
+ 
+ The `showToast` methods display any view as toast.
+ 
+ */
+public extension UIView {
+  
+  /**
+   Keys used for associated objects.
+   */
+  private struct ToastKeys {
+    static var timer = malloc(1)
+    static var duration = malloc(1)
+    static var point = malloc(1)
+    static var completion = malloc(1)
+    static var activeToasts = malloc(1)
+    static var activityView = malloc(1)
+    static var queue = malloc(1)
+  }
+  
+  /**
+   Swift closures can't be directly associated with objects via the
+   Objective-C runtime, so the (ugly) solution is to wrap them in a
+   class that can be used with associated objects.
+   */
+  private class ToastCompletionWrapper {
+    let completion: ((Bool) -> Void)?
+    
+    init(_ completion: ((Bool) -> Void)?) {
+      self.completion = completion
+    }
+  }
+  
+  private enum ToastError: Error {
+    case missingParameters
+  }
+  
+  private var activeToasts: NSMutableArray {
+    get {
+      if let activeToasts = objc_getAssociatedObject(self, &ToastKeys.activeToasts) as? NSMutableArray {
+        return activeToasts
+      } else {
+        let activeToasts = NSMutableArray()
+        objc_setAssociatedObject(self, &ToastKeys.activeToasts, activeToasts, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return activeToasts
+      }
+    }
+  }
+  
+  private var queue: NSMutableArray {
+    get {
+      if let queue = objc_getAssociatedObject(self, &ToastKeys.queue) as? NSMutableArray {
+        return queue
+      } else {
+        let queue = NSMutableArray()
+        objc_setAssociatedObject(self, &ToastKeys.queue, queue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return queue
+      }
+    }
+  }
+  
+  // MARK: - Make Toast Methods
+  
+  /**
+   Creates and presents a new toast view.
+   
+   @param message The message to be displayed
+   @param duration The toast duration
+   @param position The toast's position
+   @param title The title
+   @param image The image
+   @param style The style. The shared style will be used when nil
+   @param completion The completion closure, executed after the toast view disappears.
+   didTap will be `true` if the toast view was dismissed from a tap.
+   */
+  func makeToast(_ message: String?, duration: TimeInterval = ToastManager.shared.duration, position: ToastPosition = ToastManager.shared.position, title: String? = nil, image: UIImage? = nil, style: ToastStyle = ToastManager.shared.style, completion: ((_ didTap: Bool) -> Void)? = nil) {
+    do {
+      let toast = try toastViewForMessage(message, title: title, image: image, style: style)
+      showToast(toast, duration: duration, position: position, completion: completion)
+    } catch ToastError.missingParameters {
+      print("Error: message, title, and image are all nil")
+    } catch {}
+  }
+  
+  /**
+   Creates a new toast view and presents it at a given center point.
+   
+   @param message The message to be displayed
+   @param duration The toast duration
+   @param point The toast's center point
+   @param title The title
+   @param image The image
+   @param style The style. The shared style will be used when nil
+   @param completion The completion closure, executed after the toast view disappears.
+   didTap will be `true` if the toast view was dismissed from a tap.
+   */
+  func makeToast(_ message: String?, duration: TimeInterval = ToastManager.shared.duration, point: CGPoint, title: String?, image: UIImage?, style: ToastStyle = ToastManager.shared.style, completion: ((_ didTap: Bool) -> Void)?) {
+    do {
+      let toast = try toastViewForMessage(message, title: title, image: image, style: style)
+      showToast(toast, duration: duration, point: point, completion: completion)
+    } catch ToastError.missingParameters {
+      print("Error: message, title, and image cannot all be nil")
+    } catch {}
+  }
+  
+  // MARK: - Show Toast Methods
+  
+  /**
+   Displays any view as toast at a provided position and duration. The completion closure
+   executes when the toast view completes. `didTap` will be `true` if the toast view was
+   dismissed from a tap.
+   
+   @param toast The view to be displayed as toast
+   @param duration The notification duration
+   @param position The toast's position
+   @param completion The completion block, executed after the toast view disappears.
+   didTap will be `true` if the toast view was dismissed from a tap.
+   */
+  func showToast(_ toast: UIView, duration: TimeInterval = ToastManager.shared.duration, position: ToastPosition = ToastManager.shared.position, completion: ((_ didTap: Bool) -> Void)? = nil) {
+    let point = position.centerPoint(forToast: toast, inSuperview: self)
+    showToast(toast, duration: duration, point: point, completion: completion)
+  }
+  
+  /**
+   Displays any view as toast at a provided center point and duration. The completion closure
+   executes when the toast view completes. `didTap` will be `true` if the toast view was
+   dismissed from a tap.
+   
+   @param toast The view to be displayed as toast
+   @param duration The notification duration
+   @param point The toast's center point
+   @param completion The completion block, executed after the toast view disappears.
+   didTap will be `true` if the toast view was dismissed from a tap.
+   */
+  func showToast(_ toast: UIView, duration: TimeInterval = ToastManager.shared.duration, point: CGPoint, completion: ((_ didTap: Bool) -> Void)? = nil) {
+    objc_setAssociatedObject(toast, &ToastKeys.completion, ToastCompletionWrapper(completion), .OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    
+    if ToastManager.shared.isQueueEnabled, activeToasts.count > 0 {
+      objc_setAssociatedObject(toast, &ToastKeys.duration, NSNumber(value: duration), .OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+      objc_setAssociatedObject(toast, &ToastKeys.point, NSValue(cgPoint: point), .OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+      
+      queue.add(toast)
+    } else {
+      showToast(toast, duration: duration, point: point)
+    }
+  }
+  
+  // MARK: - Hide Toast Methods
+  
+  /**
+   Hides the active toast. If there are multiple toasts active in a view, this method
+   hides the oldest toast (the first of the toasts to have been presented).
+   
+   @see `hideAllToasts()` to remove all active toasts from a view.
+   
+   @warning This method has no effect on activity toasts. Use `hideToastActivity` to
+   hide activity toasts.
+   
+   */
+  func hideToast() {
+    guard let activeToast = activeToasts.firstObject as? UIView else { return }
+    hideToast(activeToast)
+  }
+  
+  /**
+   Hides an active toast.
+   
+   @param toast The active toast view to dismiss. Any toast that is currently being displayed
+   on the screen is considered active.
+   
+   @warning this does not clear a toast view that is currently waiting in the queue.
+   */
+  func hideToast(_ toast: UIView) {
+    guard activeToasts.contains(toast) else { return }
+    hideToast(toast, fromTap: false)
+  }
+  
+  /**
+   Hides all toast views.
+   
+   @param includeActivity If `true`, toast activity will also be hidden. Default is `false`.
+   @param clearQueue If `true`, removes all toast views from the queue. Default is `true`.
+   */
+  func hideAllToasts(includeActivity: Bool = false, clearQueue: Bool = true) {
+    if clearQueue {
+      clearToastQueue()
+    }
+    
+    activeToasts.compactMap { $0 as? UIView }
+      .forEach { hideToast($0) }
+    
+    if includeActivity {
+      hideToastActivity()
+    }
+  }
+  
+  /**
+   Removes all toast views from the queue. This has no effect on toast views that are
+   active. Use `hideAllToasts(clearQueue:)` to hide the active toasts views and clear
+   the queue.
+   */
+  func clearToastQueue() {
+    queue.removeAllObjects()
+  }
+  
+  // MARK: - Activity Methods
+  
+  /**
+   Creates and displays a new toast activity indicator view at a specified position.
+   
+   @warning Only one toast activity indicator view can be presented per superview. Subsequent
+   calls to `makeToastActivity(position:)` will be ignored until `hideToastActivity()` is called.
+   
+   @warning `makeToastActivity(position:)` works independently of the `showToast` methods. Toast
+   activity views can be presented and dismissed while toast views are being displayed.
+   `makeToastActivity(position:)` has no effect on the queueing behavior of the `showToast` methods.
+   
+   @param position The toast's position
+   */
+  func makeToastActivity(_ position: ToastPosition) {
+    // sanity
+    guard objc_getAssociatedObject(self, &ToastKeys.activityView) as? UIView == nil else { return }
+    
+    let toast = createToastActivityView()
+    let point = position.centerPoint(forToast: toast, inSuperview: self)
+    makeToastActivity(toast, point: point)
+  }
+  
+  /**
+   Creates and displays a new toast activity indicator view at a specified position.
+   
+   @warning Only one toast activity indicator view can be presented per superview. Subsequent
+   calls to `makeToastActivity(position:)` will be ignored until `hideToastActivity()` is called.
+   
+   @warning `makeToastActivity(position:)` works independently of the `showToast` methods. Toast
+   activity views can be presented and dismissed while toast views are being displayed.
+   `makeToastActivity(position:)` has no effect on the queueing behavior of the `showToast` methods.
+   
+   @param point The toast's center point
+   */
+  func makeToastActivity(_ point: CGPoint) {
+    // sanity
+    guard objc_getAssociatedObject(self, &ToastKeys.activityView) as? UIView == nil else { return }
+    
+    let toast = createToastActivityView()
+    makeToastActivity(toast, point: point)
+  }
+  
+  /**
+   Dismisses the active toast activity indicator view.
+   */
+  func hideToastActivity() {
+    if let toast = objc_getAssociatedObject(self, &ToastKeys.activityView) as? UIView {
+      UIView.animate(withDuration: ToastManager.shared.style.fadeDuration, delay: 0.0, options: [.curveEaseIn, .beginFromCurrentState], animations: {
+        toast.alpha = 0.0
+      }) { _ in
+        toast.removeFromSuperview()
+        objc_setAssociatedObject(self, &ToastKeys.activityView, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      }
+    }
+  }
+  
+  // MARK: - Helper Methods
+  
+  /**
+   Returns `true` if a toast view or toast activity view is actively being displayed.
+   */
+  func isShowingToast() -> Bool {
+    return activeToasts.count > 0 || objc_getAssociatedObject(self, &ToastKeys.activityView) != nil
+  }
+  
+  // MARK: - Private Activity Methods
+  
+  private func makeToastActivity(_ toast: UIView, point: CGPoint) {
+    toast.alpha = 0.0
+    toast.center = point
+    
+    objc_setAssociatedObject(self, &ToastKeys.activityView, toast, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    
+    self.addSubview(toast)
+    
+    UIView.animate(withDuration: ToastManager.shared.style.fadeDuration, delay: 0.0, options: .curveEaseOut, animations: {
+      toast.alpha = 1.0
+    })
+  }
+  
+  private func createToastActivityView() -> UIView {
+    let style = ToastManager.shared.style
+    
+    let activityView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: style.activitySize.width, height: style.activitySize.height))
+    activityView.backgroundColor = style.activityBackgroundColor
+    activityView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin]
+    activityView.layer.cornerRadius = style.cornerRadius
+    activityView.layer.borderWidth = style.borderWidth
+    activityView.layer.borderColor = style.borderColor
+    
+    if style.displayShadow {
+      activityView.layer.shadowColor = style.shadowColor.cgColor
+      activityView.layer.shadowOpacity = style.shadowOpacity
+      activityView.layer.shadowRadius = style.shadowRadius
+      activityView.layer.shadowOffset = style.shadowOffset
+    }
+    
+    let activityIndicatorView = UIActivityIndicatorView(style: .whiteLarge)
+    activityIndicatorView.center = CGPoint(x: activityView.bounds.size.width / 2.0, y: activityView.bounds.size.height / 2.0)
+    activityView.addSubview(activityIndicatorView)
+    activityIndicatorView.color = style.activityIndicatorColor
+    activityIndicatorView.startAnimating()
+    
+    return activityView
+  }
+  
+  // MARK: - Private Show/Hide Methods
+  
+  private func showToast(_ toast: UIView, duration: TimeInterval, point: CGPoint) {
+    toast.center = point
+    toast.alpha = 0.0
+    
+    if ToastManager.shared.isTapToDismissEnabled {
+      let recognizer = UITapGestureRecognizer(target: self, action: #selector(UIView.handleToastTapped(_:)))
+      toast.addGestureRecognizer(recognizer)
+      toast.isUserInteractionEnabled = true
+      toast.isExclusiveTouch = true
+    }
+    
+    activeToasts.add(toast)
+    self.addSubview(toast)
+    
+    let timer = Timer(timeInterval: duration, target: self, selector: #selector(UIView.toastTimerDidFinish(_:)), userInfo: toast, repeats: false)
+    objc_setAssociatedObject(toast, &ToastKeys.timer, timer, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    
+    UIView.animate(withDuration: ToastManager.shared.style.fadeDuration, delay: 0.0, options: [.curveEaseOut, .allowUserInteraction], animations: {
+      toast.alpha = 1.0
+    }) { _ in
+      guard let timer = objc_getAssociatedObject(toast, &ToastKeys.timer) as? Timer else { return }
+      RunLoop.main.add(timer, forMode: .common)
+    }
+    
+    UIAccessibility.post(notification: .screenChanged, argument: toast)
+  }
+  
+  private func hideToast(_ toast: UIView, fromTap: Bool) {
+    if let timer = objc_getAssociatedObject(toast, &ToastKeys.timer) as? Timer {
+      timer.invalidate()
+    }
+    
+    UIView.animate(withDuration: ToastManager.shared.style.fadeDuration, delay: 0.0, options: [.curveEaseIn, .beginFromCurrentState], animations: {
+      toast.alpha = 0.0
+    }) { _ in
+      toast.removeFromSuperview()
+      self.activeToasts.remove(toast)
+      
+      if let wrapper = objc_getAssociatedObject(toast, &ToastKeys.completion) as? ToastCompletionWrapper, let completion = wrapper.completion {
+        completion(fromTap)
+      }
+      
+      if let nextToast = self.queue.firstObject as? UIView, let duration = objc_getAssociatedObject(nextToast, &ToastKeys.duration) as? NSNumber, let point = objc_getAssociatedObject(nextToast, &ToastKeys.point) as? NSValue {
+        self.queue.removeObject(at: 0)
+        self.showToast(nextToast, duration: duration.doubleValue, point: point.cgPointValue)
+      }
+    }
+  }
+  
+  // MARK: - Events
+  
+  @objc
+  private func handleToastTapped(_ recognizer: UITapGestureRecognizer) {
+    guard let toast = recognizer.view else { return }
+    hideToast(toast, fromTap: true)
+  }
+  
+  @objc
+  private func toastTimerDidFinish(_ timer: Timer) {
+    guard let toast = timer.userInfo as? UIView else { return }
+    hideToast(toast)
+  }
+  
+  // MARK: - Toast Construction
+  
+  /**
+   Creates a new toast view with any combination of message, title, and image.
+   The look and feel is configured via the style. Unlike the `makeToast` methods,
+   this method does not present the toast view automatically. One of the `showToast`
+   methods must be used to present the resulting view.
+   
+   @warning if message, title, and image are all nil, this method will throw
+   `ToastError.missingParameters`
+   
+   @param message The message to be displayed
+   @param title The title
+   @param image The image
+   @param style The style. The shared style will be used when nil
+   @throws `ToastError.missingParameters` when message, title, and image are all nil
+   @return The newly created toast view
+   */
+  func toastViewForMessage(_ message: String?, title: String?, image: UIImage?, style: ToastStyle) throws -> UIView {
+    // sanity
+    guard message != nil || title != nil || image != nil else {
+      throw ToastError.missingParameters
+    }
+    
+    var messageLabel: UILabel?
+    var titleLabel: UILabel?
+    var imageView: UIImageView?
+    
+    let wrapperView = UIView()
+    wrapperView.backgroundColor = style.backgroundColor
+    wrapperView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleTopMargin, .flexibleBottomMargin]
+    wrapperView.layer.cornerRadius = style.cornerRadius
+    wrapperView.layer.borderWidth = style.borderWidth
+    wrapperView.layer.borderColor = style.borderColor
+    
+    if style.displayShadow {
+      wrapperView.layer.shadowColor = style.shadowColor.cgColor
+      wrapperView.layer.shadowOpacity = style.shadowOpacity
+      wrapperView.layer.shadowRadius = style.shadowRadius
+      wrapperView.layer.shadowOffset = style.shadowOffset
+    }
+    
+    if let image = image {
+      imageView = UIImageView(image: image)
+      imageView?.contentMode = .scaleAspectFit
+      imageView?.frame = CGRect(x: style.horizontalPadding, y: style.verticalPadding, width: style.imageSize.width, height: style.imageSize.height)
+    }
+    
+    var imageRect = CGRect.zero
+    
+    if let imageView = imageView {
+      imageRect.origin.x = style.horizontalPadding
+      imageRect.origin.y = style.verticalPadding
+      imageRect.size.width = imageView.bounds.size.width
+      imageRect.size.height = imageView.bounds.size.height
+    }
+    
+    if let title = title {
+      titleLabel = UILabel()
+      titleLabel?.numberOfLines = style.titleNumberOfLines
+      titleLabel?.font = style.titleFont
+      titleLabel?.textAlignment = style.titleAlignment
+      titleLabel?.lineBreakMode = .byTruncatingTail
+      titleLabel?.textColor = style.titleColor
+      titleLabel?.backgroundColor = UIColor.clear
+      titleLabel?.text = title;
+      
+      let maxTitleSize = CGSize(width: (self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, height: self.bounds.size.height * style.maxHeightPercentage)
+      let titleSize = titleLabel?.sizeThatFits(maxTitleSize)
+      if let titleSize = titleSize {
+        titleLabel?.frame = CGRect(x: 0.0, y: 0.0, width: titleSize.width, height: titleSize.height)
+      }
+    }
+    
+    if let message = message {
+      messageLabel = UILabel()
+      messageLabel?.text = message
+      messageLabel?.numberOfLines = style.messageNumberOfLines
+      messageLabel?.font = style.messageFont
+      messageLabel?.textAlignment = style.messageAlignment
+      messageLabel?.lineBreakMode = .byTruncatingTail;
+      messageLabel?.textColor = style.messageColor
+      messageLabel?.backgroundColor = UIColor.clear
+      
+      let maxMessageSize = CGSize(width: (self.bounds.size.width * style.maxWidthPercentage) - imageRect.size.width, height: self.bounds.size.height * style.maxHeightPercentage)
+      let messageSize = messageLabel?.sizeThatFits(maxMessageSize)
+      if let messageSize = messageSize {
+        let actualWidth = min(messageSize.width, maxMessageSize.width)
+        let actualHeight = min(messageSize.height, maxMessageSize.height)
+        messageLabel?.frame = CGRect(x: 0.0, y: 0.0, width: actualWidth, height: actualHeight)
+      }
+    }
+    
+    var titleRect = CGRect.zero
+    
+    if let titleLabel = titleLabel {
+      titleRect.origin.x = imageRect.origin.x + imageRect.size.width + style.horizontalPadding
+      titleRect.origin.y = style.verticalPadding
+      titleRect.size.width = titleLabel.bounds.size.width
+      titleRect.size.height = titleLabel.bounds.size.height
+    }
+    
+    var messageRect = CGRect.zero
+    
+    if let messageLabel = messageLabel {
+      messageRect.origin.x = imageRect.origin.x + imageRect.size.width + style.horizontalPadding
+      messageRect.origin.y = titleRect.origin.y + titleRect.size.height + style.verticalPadding
+      messageRect.size.width = messageLabel.bounds.size.width
+      messageRect.size.height = messageLabel.bounds.size.height
+    }
+    
+    let longerWidth = max(titleRect.size.width, messageRect.size.width)
+    let longerX = max(titleRect.origin.x, messageRect.origin.x)
+    let wrapperWidth = max((imageRect.size.width + (style.horizontalPadding * 2.0)), (longerX + longerWidth + style.horizontalPadding))
+    
+    let textMaxY = messageRect.size.height <= 0.0 && titleRect.size.height > 0.0 ? titleRect.maxY : messageRect.maxY
+    let wrapperHeight = max((textMaxY + style.verticalPadding), (imageRect.size.height + (style.verticalPadding * 2.0)))
+    
+    wrapperView.frame = CGRect(x: 0.0, y: 0.0, width: wrapperWidth, height: wrapperHeight)
+    
+    if let titleLabel = titleLabel {
+      titleRect.size.width = longerWidth
+      titleLabel.frame = titleRect
+      wrapperView.addSubview(titleLabel)
+    }
+    
+    if let messageLabel = messageLabel {
+      messageRect.size.width = longerWidth
+      messageLabel.frame = messageRect
+      wrapperView.addSubview(messageLabel)
+    }
+    
+    if let imageView = imageView {
+      wrapperView.addSubview(imageView)
+    }
+    
+    return wrapperView
+  }
+  
+}
+
+// MARK: - Toast Style
+
+/**
+ `ToastStyle` instances define the look and feel for toast views created via the
+ `makeToast` methods as well for toast views created directly with
+ `toastViewForMessage(message:title:image:style:)`.
+ 
+ @warning `ToastStyle` offers relatively simple styling options for the default
+ toast view. If you require a toast view with more complex UI, it probably makes more
+ sense to create your own custom UIView subclass and present it with the `showToast`
+ methods.
+ */
+public struct ToastStyle {
+  
+  public init() {}
+  
+  /**
+   The background color. Default is `.black` at 80% opacity.
+   */
+  public var backgroundColor: UIColor = DSKitAsset.Color.neutral900.color
+  
+  /**
+   The title color. Default is `UIColor.whiteColor()`.
+   */
+  public var titleColor: UIColor = .white
+  
+  /**
+   The message color. Default is `.white`.
+   */
+  public var messageColor: UIColor = DSKitAsset.Color.neutral50.color
+  
+  /**
+   A percentage value from 0.0 to 1.0, representing the maximum width of the toast
+   view relative to it's superview. Default is 0.8 (80% of the superview's width).
+   */
+  public var maxWidthPercentage: CGFloat = 0.8 {
+    didSet {
+      maxWidthPercentage = max(min(maxWidthPercentage, 1.0), 0.0)
+    }
+  }
+  
+  /**
+   A percentage value from 0.0 to 1.0, representing the maximum height of the toast
+   view relative to it's superview. Default is 0.8 (80% of the superview's height).
+   */
+  public var maxHeightPercentage: CGFloat = 0.8 {
+    didSet {
+      maxHeightPercentage = max(min(maxHeightPercentage, 1.0), 0.0)
+    }
+  }
+  
+  /**
+   The spacing from the horizontal edge of the toast view to the content. When an image
+   is present, this is also used as the padding between the image and the text.
+   Default is 24.0.
+   
+   */
+  public var horizontalPadding: CGFloat = 24.0
+  
+  /**
+   The spacing from the vertical edge of the toast view to the content. When a title
+   is present, this is also used as the padding between the title and the message.
+   Default is 12.0. On iOS11+, this value is added added to the `safeAreaInset.top`
+   and `safeAreaInsets.bottom`.
+   */
+  public var verticalPadding: CGFloat = 12.0
+  
+  /**
+   The corner radius. Default is 38.0.
+   */
+  public var cornerRadius: CGFloat = 25.0;
+  
+  public var borderWidth: CGFloat = 1.0;
+  
+  public var borderColor: CGColor = DSKitAsset.Color.neutral600.color.cgColor
+  
+  /**
+   The title font. Default is `.boldSystemFont(16.0)`.
+   */
+  public var titleFont: UIFont = .boldSystemFont(ofSize: 16.0)
+  
+  /**
+   The message font. Default is `.systemFont(ofSize: 16.0)`.
+   */
+  public var messageFont: UIFont = UIFont.thtP2Sb
+  
+  /**
+   The title text alignment. Default is `NSTextAlignment.Center`.
+   */
+  public var titleAlignment: NSTextAlignment = .center
+  
+  /**
+   The message text alignment. Default is `NSTextAlignment.Center`.
+   */
+  public var messageAlignment: NSTextAlignment = .center
+  
+  /**
+   The maximum number of lines for the title. The default is 0 (no limit).
+   */
+  public var titleNumberOfLines = 0
+  
+  /**
+   The maximum number of lines for the message. The default is 0 (no limit).
+   */
+  public var messageNumberOfLines = 0
+  
+  /**
+   Enable or disable a shadow on the toast view. Default is `true`.
+   */
+  public var displayShadow = true
+  
+  /**
+   The shadow color. Default is `.black`.
+   */
+  public var shadowColor: UIColor = DSKitAsset.Color.DimColor.signUpDim.color
+  
+  /**
+   A value from 0.0 to 1.0, representing the opacity of the shadow.
+   Default is 0.8 (80% opacity).
+   */
+  public var shadowOpacity: Float = 0.8 {
+    didSet {
+      shadowOpacity = max(min(shadowOpacity, 1.0), 0.0)
+    }
+  }
+  
+  /**
+   The shadow radius. Default is 6.0.
+   */
+  public var shadowRadius: CGFloat = 4.0
+  
+  /**
+   The shadow offset. The default is 4 x 4.
+   */
+  public var shadowOffset = CGSize(width: 2.0, height: 2.0)
+  
+  /**
+   The image size. The default is 80 x 80.
+   */
+  public var imageSize = CGSize(width: 80.0, height: 80.0)
+  
+  /**
+   The size of the toast activity view when `makeToastActivity(position:)` is called.
+   Default is 100 x 100.
+   */
+  public var activitySize = CGSize(width: 100.0, height: 100.0)
+  
+  /**
+   The fade in/out animation duration. Default is 0.2.
+   */
+  public var fadeDuration: TimeInterval = 0.2
+  
+  /**
+   Activity indicator color. Default is `.white`.
+   */
+  public var activityIndicatorColor: UIColor = .white
+  
+  /**
+   Activity background color. Default is `.black` at 80% opacity.
+   */
+  public var activityBackgroundColor: UIColor = UIColor.black.withAlphaComponent(0.8)
+  
+}
+
+// MARK: - Toast Manager
+
+/**
+ `ToastManager` provides general configuration options for all toast
+ notifications. Backed by a singleton instance.
+ */
+public class ToastManager {
+  
+  /**
+   The `ToastManager` singleton instance.
+   
+   */
+  public static let shared = ToastManager()
+  
+  /**
+   The shared style. Used whenever toastViewForMessage(message:title:image:style:) is called
+   with with a nil style.
+   
+   */
+  public var style = ToastStyle()
+  
+  /**
+   Enables or disables tap to dismiss on toast views. Default is `true`.
+   
+   */
+  public var isTapToDismissEnabled = true
+  
+  /**
+   Enables or disables queueing behavior for toast views. When `true`,
+   toast views will appear one after the other. When `false`, multiple toast
+   views will appear at the same time (potentially overlapping depending
+   on their positions). This has no effect on the toast activity view,
+   which operates independently of normal toast views. Default is `false`.
+   
+   */
+  public var isQueueEnabled = false
+  
+  /**
+   The default duration. Used for the `makeToast` and
+   `showToast` methods that don't require an explicit duration.
+   Default is 3.0.
+   
+   */
+  public var duration: TimeInterval = 3.0
+  
+  /**
+   Sets the default position. Used for the `makeToast` and
+   `showToast` methods that don't require an explicit position.
+   Default is `ToastPosition.Bottom`.
+   
+   */
+  public var position: ToastPosition = .bottom
+  
+}
+
+// MARK: - ToastPosition
+
+public enum ToastPosition {
+  case top
+  case center
+  case bottom
+  
+  fileprivate func centerPoint(forToast toast: UIView, inSuperview superview: UIView) -> CGPoint {
+    let topPadding: CGFloat = ToastManager.shared.style.verticalPadding + superview.csSafeAreaInsets.top
+    let bottomPadding: CGFloat = ToastManager.shared.style.verticalPadding + superview.csSafeAreaInsets.bottom
+    
+    switch self {
+    case .top:
+      return CGPoint(x: superview.bounds.size.width / 2.0, y: (toast.frame.size.height / 2.0) + topPadding)
+    case .center:
+      return CGPoint(x: superview.bounds.size.width / 2.0, y: superview.bounds.size.height / 2.0)
+    case .bottom:
+      return CGPoint(x: superview.bounds.size.width / 2.0, y: (superview.bounds.size.height - (toast.frame.size.height / 2.0)) - bottomPadding)
+    }
+  }
+}
+
+// MARK: - Private UIView Extensions
+
+private extension UIView {
+  
+  var csSafeAreaInsets: UIEdgeInsets {
+    if #available(iOS 11.0, *) {
+      return self.safeAreaInsets
+    } else {
+      return .zero
+    }
+  }
+  
+}

--- a/Projects/Modules/DesignSystem/Src/Util/UIVIewControler+Utils.swift
+++ b/Projects/Modules/DesignSystem/Src/Util/UIVIewControler+Utils.swift
@@ -10,71 +10,78 @@ import UIKit
 extension UIViewController {
   public func showAlert(title: String? = nil,
                         message: String? = nil,
-                        attributedMessage: NSAttributedString? = nil,
-                        leftActionTitle: String? = "확인",
-                        rightActionTitle: String = "취소",
-                        leftActionCompletion: (() -> Void)? = nil,
-                        rightActionCompletion: (() -> Void)? = nil,
+                        topActionTitle: String? = "확인",
+                        bottomActionTitle: String = "취소",
+                        dimColor: UIColor = DSKitAsset.Color.DimColor.default.color,
+                        topActionCompletion: (() -> Void)? = nil,
+                        bottomActionCompletion: (() -> Void)? = nil,
                         dimActionCompletion: (() -> Void)? = nil) {
     let alertViewController = TFAlertViewController(titleText: title,
-                                                    messageText: message)
+                                                    messageText: message,
+                                                    dimColor: dimColor)
     showAlert(alertViewController: alertViewController,
-              leftActionTitle: leftActionTitle,
-              rightActionTitle: rightActionTitle,
-              leftActionCompletion: leftActionCompletion,
-              rightActionCompletion: rightActionCompletion,
+              topActionTitle: topActionTitle,
+              bottomActionTitle: bottomActionTitle,
+              topActionCompletion: topActionCompletion,
+              bottomActionCompletion: bottomActionCompletion,
               dimActionCompletion: dimActionCompletion)
   }
   
   public func showAlert(contentView: UIView,
-                        leftActionTitle: String? = "확인",
-                        rightActionTitle: String = "취소",
-                        leftActionCompletion: (() -> Void)? = nil,
-                        rightActionCompletion: (() -> Void)? = nil,
+                        topActionTitle: String? = "확인",
+                        bottomActionTitle: String = "취소",
+                        dimColor: UIColor = DSKitAsset.Color.DimColor.default.color,
+                        topActionCompletion: (() -> Void)? = nil,
+                        bottomActionCompletion: (() -> Void)? = nil,
                         dimActionCompletion: (() -> Void)? = nil) {
-    let alertViewController = TFAlertViewController(contentView: contentView)
+    let alertViewController = TFAlertViewController(contentView: contentView,
+                                                    dimColor: dimColor)
     
     showAlert(alertViewController: alertViewController,
-              leftActionTitle: leftActionTitle,
-              rightActionTitle: rightActionTitle,
-              leftActionCompletion: leftActionCompletion,
-              rightActionCompletion: rightActionCompletion,
+              topActionTitle: topActionTitle,
+              bottomActionTitle: bottomActionTitle,
+              topActionCompletion: topActionCompletion,
+              bottomActionCompletion: bottomActionCompletion,
               dimActionCompletion: dimActionCompletion)
   }
   
   public func showAlert(action: ReportAction,
-                        leftActionCompletion: (() -> Void)? = nil,
-                        rightActionCompletion: (() -> Void)? = nil,
+                        dimColor: UIColor = DSKitAsset.Color.DimColor.default.color,
+                        topActionCompletion: (() -> Void)? = nil,
+                        bottomActionCompletion: (() -> Void)? = nil,
                         dimActionCompletion: (() -> Void)? = nil) {
-    let alertViewController = TFAlertViewController(
-      titleText: action.title,
-      messageText: action.message
-    )
+    let alertViewController = TFAlertViewController(titleText: action.title,
+                                                    messageText: action.message,
+                                                    dimColor: dimColor)
     
     showAlert(alertViewController: alertViewController,
-              leftActionTitle: action.leftActionTitle,
-              rightActionTitle: action.rightActionTitle,
-              leftActionCompletion: leftActionCompletion,
-              rightActionCompletion: rightActionCompletion,
+              topActionTitle: action.topActionTitle,
+              bottomActionTitle: action.bottomActionTitle,
+              topActionCompletion: topActionCompletion,
+              bottomActionCompletion: bottomActionCompletion,
               dimActionCompletion: dimActionCompletion)
   }
   
   private func showAlert(alertViewController: TFAlertViewController,
-                         leftActionTitle: String?,
-                         rightActionTitle: String,
-                         leftActionCompletion: (() -> Void)?,
-                         rightActionCompletion: (() -> Void)?,
+                         topActionTitle: String?,
+                         bottomActionTitle: String,
+                         topActionCompletion: (() -> Void)?,
+                         bottomActionCompletion: (() -> Void)?,
                          dimActionCompletion: (() -> Void)?) {
-    alertViewController.addActionToButton(title: leftActionTitle) {
-      alertViewController.dismiss(animated: false, completion: leftActionCompletion)
+    alertViewController.addActionToButton(title: topActionTitle) {
+      alertViewController.dismiss(animated: false, 
+                                  completion: topActionCompletion)
     }
     
-    alertViewController.addActionToButton(title: rightActionTitle) {
-      alertViewController.dismiss(animated: false, completion: rightActionCompletion)
+    alertViewController.addActionToButton(title: bottomActionTitle, 
+                                          withSeparator: true) {
+      alertViewController.dismiss(animated: false, 
+                                  completion: bottomActionCompletion)
     }
     
     alertViewController.addActionToDim() {
-      alertViewController.dismiss(animated: false, completion: dimActionCompletion)
+      alertViewController.dismiss(animated: false, 
+                                  completion: dimActionCompletion)
     }
     
     present(alertViewController, animated: false, completion: nil)


### PR DESCRIPTION
## Motivation ⍰

- 유저 차단 또는 삭제 시, 디자인 반영을 위함
- user info box 팝업에서 report(느낌표) 버튼 클릭 시, 멈춤 화면 디자인 반영
- 차단 or 신고 팝업 표시 시, 멈춤 화면에서 이미지, 텍스트 히든
- 중지했을 때의 동작을 enum으로 나눠서 처리할 필요 없는 거 같아서 bool로 변경
- 차단 or 신고 시, 멈춤 화면 없애고 dim view 표시 후, none 상태로 설정

<br>

## Key Changes 🔑

구현 미리보기 입니다.
<img src="https://github.com/THT-Team/THT-iOS/assets/68800789/1965442b-0f7c-48ae-972a-37b74edb10f9" width=25%>

유저 차단 또는 삭제 시, none(0초인 상태)로 만들기 위해서 강제로 -1초를 설정하는데,
여기서 다음 유저 셀의 시간을 active를 하면 이전 셀의 시간에 영향을 받게 되는데 이유를 모르겠습니다.
셀마다 타이머를 관리하기 때문에 이전 유저의 타이머가 0초가 되는 것이 상관없다고 생각했습니다.(셀마다 뷰모델이 있고, 인덱스가 넘어갈 때만 시간을 active하기 때문)

<br>

## To Reviewers 🙏🏻

- [x] 유저 차단 혹은 신고했을 때의 디자인과 동일한 지 봐주세요

<br>

## Linked Issue 🔗

- [ ] #74 
