### PR TITLE
Fix: (#85) lottie view ratio

### DIFF
--- a/Projects/Features/Auth/Src/AuthRoot/Certificate/SubView/SuccessCertificationView.swift
+++ b/Projects/Features/Auth/Src/AuthRoot/Certificate/SubView/SuccessCertificationView.swift
@@ -14,6 +14,7 @@ final class SuccessCertificationView: UIView {
 
   private lazy var backCardView = UIView().then {
     $0.layer.cornerRadius = 12
+    $0.layer.masksToBounds = true
     $0.backgroundColor = DSKitAsset.Color.neutral600.color
   }
 
@@ -31,6 +32,7 @@ final class SuccessCertificationView: UIView {
   }
 
   func makeUI() {
+    self.animationView.contentMode = .scaleAspectFill
     self.backgroundColor = DSKitAsset.Color.DimColor.signUpDim.color
 
     self.addSubview(backCardView)
@@ -47,7 +49,7 @@ final class SuccessCertificationView: UIView {
     animationView.snp.makeConstraints {
       $0.centerX.equalToSuperview()
       $0.top.equalToSuperview().offset(69)
-      $0.height.equalToSuperview().multipliedBy(0.469)
+      $0.height.equalToSuperview().multipliedBy(0.470)
       $0.width.equalToSuperview().multipliedBy(0.852)
     }
 


### PR DESCRIPTION
기존 소스코드가 비율은 맞았으나 contentMode가 안맞았음

## Motivation ⍰

- SIgnUp QA

<br>

## Key Changes 🔑

- Lottie View contentMode를 scaleAspectFill로 수정

<br>

## To Reviewers 🙏🏻

- [ ] 비율 확인
<img src="https://www.notion.so/image/https%3A%2F%2Fprod-files-secure.s3.us-west-2.amazonaws.com%2Ff087c1b8-2d5a-46e7-a738-a4696139f9d9%2Fd807fdf6-a8e1-445a-9975-3c6f5852653c%2F%25E1%2584%2589%25E1%2585%25B3%25E1%2584%258F%25E1%2585%25B3%25E1%2584%2585%25E1%2585%25B5%25E1%2586%25AB%25E1%2584%2589%25E1%2585%25A3%25E1%2586%25BA_2024-06-15_%25E1%2584%258B%25E1%2585%25A9%25E1%2584%2592%25E1%2585%25AE_4.44.16.png?id=66fdf3fc-76e1-42d5-8bc7-c719c9d3d1c3&table=block&spaceId=f087c1b8-2d5a-46e7-a738-a4696139f9d9&width=2000&userId=5a6076c9-6c4b-4317-bf19-6c68f01be7c8&cache=v2" width=300>

<br>

## Linked Issue 🔗

- #85 
