### PR TITLE
Mod: Alert UI Change (#84)

### DIFF
--- a/Projects/Core/Src/BaseType/Pulse.swift
+++ b/Projects/Core/Src/BaseType/Pulse.swift
@@ -1,0 +1,37 @@
+//
+//  Pulse.swift
+//  Core
+//
+//  Created by Kanghos on 6/28/24.
+//
+
+import Foundation
+
+@propertyWrapper
+public struct Pulse<Value> {
+
+  public var value: Value {
+    didSet {
+      riseValueUpdatedCount()
+    }
+  }
+
+  public internal(set) var valueUpdatedCount = UInt.min
+
+  public init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  public var wrappedValue: Value {
+    get { value }
+    set { value = newValue }
+  }
+
+  public var projectedValue: Pulse<Value> {
+    self
+  }
+
+  private mutating func riseValueUpdatedCount() {
+    valueUpdatedCount &+= 1
+  }
+}

--- a/Projects/Data/Src/Repository/Falling/FallingTarget+SampleData.swift
+++ b/Projects/Data/Src/Repository/Falling/FallingTarget+SampleData.swift
@@ -18,8 +18,8 @@ extension FallingTarget {
           "topicExpirationUnixTime": 1451021213,
           "userInfos": [
             {
-              "username": "매칭된 유저 이름1",
-              "userUuid": "매칭된 유저 uuid",
+              "username": "1매칭된 유저 이름1",
+              "userUuid": "asldkfjalkfjdaflkj",
               "age": 24,
               "address": "인천광역시 부평구 ",
               "isBirthDay": true,
@@ -75,8 +75,8 @@ extension FallingTarget {
               "userDailyFallingCourserIdx": 1
             },
             {
-              "username": "매칭된 유저 이름2",
-              "userUuid": "매칭된 유저 uuid",
+              "username": "2매칭된 유저 이름2",
+              "userUuid": "asdfjsdbnasdkfkasdlf",
               "age": 24,
               "address": "인천광역시 부평구 ",
               "isBirthDay": true,
@@ -132,7 +132,7 @@ extension FallingTarget {
               "userDailyFallingCourserIdx": 2
             },
             {
-              "username": "매칭된 유저 이름3",
+              "username": "3매칭된 유저 이름3",
               "userUuid": "매칭된 유저 uuid",
               "age": 24,
               "address": "인천광역시 부평구 ",
@@ -187,11 +187,68 @@ extension FallingTarget {
               ],
               "introduction": "유저 자기소개",
               "userDailyFallingCourserIdx": 3
-            }
+            },
+                    {
+                      "username": "4매칭된 유저 이름4",
+                      "userUuid": "asldkfjalkfjdafasdfasfdalkj",
+                      "age": 24,
+                      "address": "인천광역시 부평구 ",
+                      "isBirthDay": true,
+                      "idealTypeResponseList": [
+                        {
+                          "idx": 1,
+                          "name": "자극을 주는",
+                          "emojiCode": "1F4DA"
+                        },
+                        {
+                          "idx": 2,
+                          "name": "피부가 좋은",
+                          "emojiCode": "1F3AC"
+                        },
+                        {
+                          "idx": 3,
+                          "name": "집순이/집돌이",
+                          "emojiCode": "1F3B5"
+                        }
+                      ],
+                      "interestResponses": [
+                        {
+                          "idx": 1,
+                          "name": "등산하기",
+                          "emojiCode": "1F3A4"
+                        },
+                        {
+                          "idx": 2,
+                          "name": "영화/드라마",
+                          "emojiCode": "1F642"
+                        },
+                        {
+                          "idx": 3,
+                          "name": "게임",
+                          "emojiCode": "1F963"
+                        }
+                      ],
+                      "userProfilePhotos": [
+                        {
+                          "url": "https://cdn.pixabay.com/photo/2024/01/15/21/16/dog-8510901_640.jpg",
+                          "priority": 1
+                        },
+                        {
+                          "url": "https://firebasestorage.googleapis.com/v0/b/tht-falling.appspot.com/o/images%2Fprofile_example1.png?alt=media&token=dc28c0cd-98b2-4332-9660-35530283d77c",
+                          "priority": 2
+                        },
+                        {
+                          "url": "https://firebasestorage.googleapis.com/v0/b/tht-falling.appspot.com/o/images%2Fprofile_example2.png?alt=media&token=e19493ed-10ba-4784-bf94-f4b99af84161",
+                          "priority": 3
+                        }
+                      ],
+                      "introduction": "유저 자기소개",
+                      "userDailyFallingCourserIdx": 4
+                    },
           ]
         }
         """.utf8
-        )
+      )
     default:
       return Data(
     """

--- a/Projects/Data/Src/Repository/MyPage/MyPageRepository.swift
+++ b/Projects/Data/Src/Repository/MyPage/MyPageRepository.swift
@@ -22,7 +22,7 @@ public final class MyPageRepository: ProviderProtocol {
   public var provider: MoyaProvider<Target>
 
   public init() {
-    self.provider = MoyaProvider()
+    self.provider = Self.makeStubProvider()
   }
   public init(isStub: Bool, sampleStatusCode: Int, customEndpointClosure: ((Target) -> Moya.Endpoint)?) {
     self.provider = MyPageRepository.consProvider(isStub, sampleStatusCode, customEndpointClosure)
@@ -35,12 +35,17 @@ extension MyPageRepository: MyPageRepositoryInterface {
     .just(1)
   }
   
-  public func updateUserContacts(contacts: [ContactType]) -> RxSwift.Single<Int> {
-    .just(1)
+  public func updateUserContacts(contacts: [SignUpInterface.ContactType]) -> RxSwift.Single<Int> {
+    request(type: UserFriendContactRes.self, target: .updateUserContacts(contacts))
+      .map { $0.count }
   }
 
   public func fetchUser() -> Single<User> {
     request(type: UserDetailRes.self, target: .user)
       .map { $0.toDomain() }
+  }
+
+  public func updateAlarmSetting(_ settings: [String: Bool]) -> Completable {
+    requestWithNoContent(target: .updateAlarmSetting(settings))
   }
 }

--- a/Projects/Data/Src/Repository/SignUp/SignUpRepository.swift
+++ b/Projects/Data/Src/Repository/SignUp/SignUpRepository.swift
@@ -15,6 +15,8 @@ import RxSwift
 import RxMoya
 import Moya
 
+import Core
+
 public final class SignUpRepository: ProviderProtocol {
 
   public typealias Target = SignUpTarget

--- a/Projects/Features/Auth/Src/UseCase/AuthUseCase.swift
+++ b/Projects/Features/Auth/Src/UseCase/AuthUseCase.swift
@@ -8,6 +8,7 @@
 import Foundation
 import AuthInterface
 import RxSwift
+import Core
 
 import Core
 

--- a/Projects/Features/Falling/Interface/Src/Coordinator/FallingCoordinating.swift
+++ b/Projects/Features/Falling/Interface/Src/Coordinator/FallingCoordinating.swift
@@ -31,6 +31,7 @@ public enum FallingHomeNavigationAction {
   case toReportBlockAlert(listener: BlockOrReportAlertListener)
   case toReportAlert(listener: ReportAlertListener)
   case toBlockAlert(listener: BlockAlertListener)
+  case toChatRoom(chatRoomIndex: Int)
 }
 
 public protocol FallingHomeActionDelegate: AnyObject {

--- a/Projects/Features/Falling/Interface/Src/FallingUseCaseInterface.swift
+++ b/Projects/Features/Falling/Interface/Src/FallingUseCaseInterface.swift
@@ -11,5 +11,9 @@ import RxSwift
 
 public protocol FallingUseCaseInterface {
   func user(alreadySeenUserUUIDList: [String], userDailyFallingCourserIdx: Int, size: Int) -> Single<FallingUserInfo>
+  func block(userUUID: String) -> Single<Void>
+  func report(userUUID: String, reason: String) -> Single<Void>
+  func like(userUUID: String, topicIndex: String) -> Single<Bool>
+  func reject(userUUID: String, topicIndex: String) -> Single<Void>
 }
 

--- a/Projects/Features/Falling/Interface/Src/Model/FallingUser.swift
+++ b/Projects/Features/Falling/Interface/Src/Model/FallingUser.swift
@@ -56,7 +56,7 @@ public struct FallingUserInfo {
 }
 
 public struct FallingUser {
-  public let identifer = UUID()
+  public var identifer: String { return userUUID }
   public let username, userUUID: String
   public let age: Int
   public let address: String

--- a/Projects/Features/Falling/Src/Coordinator/FallingCoordinator.swift
+++ b/Projects/Features/Falling/Src/Coordinator/FallingCoordinator.swift
@@ -31,7 +31,7 @@ public final class FallingCoordinator: BaseCoordinator, FallingCoordinating {
   }
 
   public func chatRoomFlow() {
-    //    TFLogger.dataLogger.info("ChatRoom!")
+        TFLogger.dataLogger.info("ChatRoom!")
   }
 }
 
@@ -63,6 +63,8 @@ extension FallingCoordinator: FallingHomeActionDelegate {
       userReportAlert(listener)
     case let .toBlockAlert(listener):
       blockAlertFlow(listener)
+    case let .toChatRoom(chatRoomIndex):
+      chatRoomFlow()
     }
   }
 }

--- a/Projects/Features/Falling/Src/FallingUseCase.swift
+++ b/Projects/Features/Falling/Src/FallingUseCase.swift
@@ -12,6 +12,7 @@ import FallingInterface
 import RxSwift
 
 public final class FallingUseCase: FallingUseCaseInterface {
+
   private let repository: FallingRepositoryInterface
   
   public init(repository: FallingRepositoryInterface) {
@@ -25,5 +26,22 @@ public final class FallingUseCase: FallingUseCaseInterface {
       size: size
     )
   }
+
+  public func block(userUUID: String) -> Single<Void> {
+    .just(())
+  }
+
+  public func report(userUUID: String, reason: String) -> Single<Void> {
+    .just(())
+  }
+
+  public func like(userUUID: String, topicIndex: String) -> RxSwift.Single<Bool> {
+    return .just([true, false].randomElement() ?? false)
+  }
+
+  public func reject(userUUID: String, topicIndex: String) -> RxSwift.Single<Void> {
+    return .just(())
+  }
+
 }
 

--- a/Projects/Features/Falling/Src/Home/FallingHomeView.swift
+++ b/Projects/Features/Falling/Src/Home/FallingHomeView.swift
@@ -52,7 +52,7 @@ extension NSCollectionLayoutSection {
     
     let layoutGroupSize = NSCollectionLayoutSize(
       widthDimension: .fractionalWidth(1.0),
-      heightDimension: .estimated(estimatedHeight)
+      heightDimension: .fractionalHeight(586/(844 - 180))
     )
     
     let layoutGroup = NSCollectionLayoutGroup.vertical(
@@ -104,7 +104,11 @@ extension NSCollectionLayoutSection {
     
     let section = NSCollectionLayoutSection(group: layoutGroup)
     section.orthogonalScrollingBehavior = .paging
-    
+
+    section.visibleItemsInvalidationHandler = { items, offset, environment in
+
+    }
+
     return section
   }
 }

--- a/Projects/Features/Falling/Src/Home/FallingHomeViewModel.swift
+++ b/Projects/Features/Falling/Src/Home/FallingHomeViewModel.swift
@@ -13,124 +13,346 @@ import RxCocoa
 import Foundation
 
 final class FallingHomeViewModel: ViewModelType {
-  
+  typealias CellType = FallingUserCollectionViewCell
+
   private let fallingUseCase: FallingUseCaseInterface
-  
-  //  weak var delegate: FallingHomeDelegate?
 
   weak var delegate: FallingHomeActionDelegate?
 
   var disposeBag: DisposeBag = DisposeBag()
+
+  private let timer = TFTimer(startTime: 15.0)
+
   private let alertActionSignal = PublishRelay<FallingHomeAlertAction>()
 
   struct Input {
     let initialTrigger: Driver<Void>
-    let timeOverTrigger: Driver<AnimationAction>
-    let cellButtonAction: Driver<FallingCellButtonAction>
-    let reportButtonTapTrigger: Signal<Void>
+    let viewDidAppear: Driver<Void>
+    let viewWillDisappear: Driver<Void>
+    let cellButtonAction: Driver<CellType.Action>
+    let deleteAnimationComplete: Signal<Void>
   }
-  
+
   struct Output {
-    let userList: Driver<[FallingUser]>
-    let nextCardIndexPath: Driver<IndexPath>
-    let likeButtonAction: Driver<IndexPath>
-    let rejectButtonAction: Driver<IndexPath>
-    let deleteCard: Driver<IndexPath>
-    let activateTimer: Signal<Void>
-    let toast: Signal<String>
+    let state: Driver<State>
   }
-  
+
+  enum ScrollAction: Equatable {
+    case scrollAfterDelete(FallingUser)
+    case scroll(IndexPath)
+    case pause
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      switch(lhs, rhs) {
+      case let (.scroll(lhsValue), .scroll(rhsValue)):
+        return lhsValue == rhsValue
+      case (.pause, .pause): return true
+      case let (.scrollAfterDelete(lhsValue), .scrollAfterDelete(rhsValue)):
+        return lhsValue == rhsValue
+      default: return false
+      }
+    }
+  }
+
+  private enum ScrollActionType {
+    case scroll
+    case pause
+    case scrollAfterDelete(FallingUser)
+  }
+
+  struct State: Equatable {
+    var index: Int = 0
+    var snapshot: [FallingUser] = []
+    var topicIndex: String = ""
+    @Pulse var scrollAction: ScrollAction = .pause
+    @Pulse var toast: String? = nil
+    @Pulse var timeState: TimeState = .none
+    @Pulse var shouldShowPause: Bool = false
+
+    var indexPath: IndexPath {
+      IndexPath(row: index, section: 0)
+    }
+
+    var user: FallingUser? {
+      snapshot[safe: index]
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      lhs.index == rhs.index &&
+      lhs.snapshot == rhs.snapshot &&
+      lhs.scrollAction == rhs.scrollAction
+    }
+  }
+
+  private enum Mutation {
+    case setScrollEvent(ScrollActionType)
+    case updateIndexPath(Int)
+    case removeSnapshot(FallingUser)
+    case fetchUser([FallingUser])
+
+    case selectAlert
+    case toChatRoom(String)
+    case toast(String)
+
+    // MARK: Timer
+    case stopTimer
+    case startTimer
+    case resetTimer
+    case setTimeState(TimeState)
+
+    // MARK: Cell
+    case hidePause
+    case showPause
+  }
+
   init(fallingUseCase: FallingUseCaseInterface) {
     self.fallingUseCase = fallingUseCase
   }
-  
+
+  let initialState = State()
+  var currentState: State {
+    get { (try? state.value()) ?? initialState }
+    set { state.onNext(newValue) }
+  }
+  lazy var state = BehaviorSubject<State>(value: initialState)
+  var shareState: Observable<State> {
+    state.share()
+  }
+
+  let scrollCommand = PublishRelay<ScrollAction>()
+
   func transform(input: Input) -> Output {
-    let currentIndexRelay = BehaviorRelay<Int>(value: 0)
-    let timeOverTrigger = input.timeOverTrigger
-    let snapshot = BehaviorRelay<[FallingUser]>(value: [])
-    let toast = PublishRelay<String>()
+    let mutation = transform(action: input)
+    let transfromMutation = transform(mutation: mutation)
 
-    let usersResponse = input.initialTrigger
-      .flatMapLatest { [unowned self] _ in
-        self.fallingUseCase.user(alreadySeenUserUUIDList: [], userDailyFallingCourserIdx: 1, size: 100)
-          .asDriver(onErrorJustReturn: .init(selectDailyFallingIdx: 0, topicExpirationUnixTime: 0, userInfos: []))
+    let state = transfromMutation
+      .scan(initialState) { [weak self] state, mutation -> State in
+        guard let self else { return state }
+        return self.reduce(state: state, mutation: mutation)
       }
-    
-    let userList = usersResponse.map {
-      snapshot.accept($0.userInfos)
-      return $0.userInfos
-    }
-    
-    let updateUserListTrigger = userList.map { _ in
-      currentIndexRelay.accept(currentIndexRelay.value)
-    }
-    
-    let updateScrollIndexTrigger = timeOverTrigger.withLatestFrom(currentIndexRelay.asDriver(onErrorJustReturn: 0)) { action, index in
-      switch action {
-      case .scroll: currentIndexRelay.accept(index + 1)
-      case .delete: currentIndexRelay.accept(index + 1)
-      }
-    }
-    
-    let nextCardIndexPath = Driver.merge(
-      updateUserListTrigger,
-      updateScrollIndexTrigger
-    ).withLatestFrom(currentIndexRelay.asDriver(onErrorJustReturn: 0)
-      .map { IndexPath(row: $0, section: 0) })
-    
-    let likeButtonAction = input.cellButtonAction
-      .compactMap { action -> IndexPath? in
-        if case let .like(indexPath) = action {
-          return indexPath
-        }
-        return nil
-      }
-    
-    let rejectButtonAction = input.cellButtonAction
-      .compactMap { action -> IndexPath? in
-        if case let .reject(indexPath) = action {
-          return indexPath
-        }
-        return nil
-      }
+      .startWith(initialState)
 
-    input.reportButtonTapTrigger
-      .emit(with: self) { owner, _ in
-        owner.delegate?.invoke(.toReportBlockAlert(listener: owner))
-      }.disposed(by: disposeBag)
-
-    // TODO: block과 report 분기해서 API 태우기
-    let reportAndBlockTrigger = self.alertActionSignal
-      .filter { $0 != .cancel }
-
-    let deleteCard = reportAndBlockTrigger
-      .withLatestFrom(currentIndexRelay)
-      .map { IndexPath(item: $0, section: 0) }
+    let transfromState = transform(state: state)
+      .do(onNext: { [weak self] in self?.currentState = $0 })
       .asDriverOnErrorJustEmpty()
 
-      reportAndBlockTrigger
-      .withLatestFrom(currentIndexRelay) { action, index in
-        (action, IndexPath(item: index, section: 0))
-      }
-      .asDriverOnErrorJustEmpty()
-      .drive(with: self) { owner, component in
-        let (action, indexPath) = component
-        // TODO: action을 신고 차단 따라서 API 태우기 + user UUID 같이
-        print(action)
-        print("API 태우기")
-        toast.accept("차단하기가 완료되었습니다. 해당 사용자와\n서로 차단되며 설정에서 확인 가능합니다.")
-      }
+    transfromState
+      .drive(self.state)
       .disposed(by: disposeBag)
 
     return Output(
-      userList: userList,
-      nextCardIndexPath: nextCardIndexPath,
-      likeButtonAction: likeButtonAction,
-      rejectButtonAction: rejectButtonAction,
-      deleteCard: deleteCard,
-      activateTimer: self.alertActionSignal.asSignal().map { _ in },
-      toast: toast.asSignal()
+      state: transfromState
     )
+  }
+}
+
+extension FallingHomeViewModel {
+  private func transform(action input: Input) -> Observable<Mutation> {
+    Observable.merge(
+      input.viewWillDisappear
+        .asObservable()
+        .flatMap { _ -> Observable<Mutation> in
+          return .concat(
+            .just(.stopTimer),
+            .just(.showPause)
+          )
+        },
+      input.viewDidAppear
+        .asObservable()
+        .flatMap({ _ -> Observable<Mutation> in
+          return .concat(
+
+            .empty()
+            )
+        }),
+      input.cellButtonAction
+        .asObservable()
+        .withLatestFrom(state) { ($0, $1) }
+        .flatMap({ [weak self] action, state -> Observable<Mutation> in
+          guard let self, let user = state.user else { return .empty() }
+          switch action {
+          case .likeTap:
+            return self.fallingUseCase.like(userUUID: user.userUUID, topicIndex: state.topicIndex)
+              .asObservable()
+              .flatMap({ isMatched -> Observable<Mutation> in
+                if isMatched {
+                  return .concat(
+                    .just(.toChatRoom("1111")),
+                    .just(.stopTimer)
+                  )
+                }
+                return .concat (
+                  .just(.updateIndexPath(1))
+                )
+              })
+              .catch { .concat(.just(.toast($0.localizedDescription)))}
+          case .rejectTap:
+            return self.fallingUseCase.reject(userUUID: user.userUUID, topicIndex: state.topicIndex)
+              .asObservable()
+              .flatMap { _ -> Observable<Mutation> in
+                return .concat (
+                  .just(.updateIndexPath(1))
+                )
+              }
+              .catch { .concat(
+                .just(.toast($0.localizedDescription))
+              )}
+          case .reportTap:
+            return .concat(
+              .just(.selectAlert),
+              .just(.stopTimer)
+            )
+          case .pause(let shouldPause):
+            return shouldPause ? .just(.stopTimer) : .just(.startTimer)
+          }
+        }),
+
+      input.initialTrigger
+        .asObservable()
+        .flatMap { [unowned self] _ in
+          self.fallingUseCase.user(alreadySeenUserUUIDList: [], userDailyFallingCourserIdx: 1, size: 100)
+            .asObservable()
+            .catchAndReturn(.init(selectDailyFallingIdx: 0, topicExpirationUnixTime: 0, userInfos: []))
+        }
+        .flatMap { snapshot -> Observable<Mutation> in
+          return .concat(
+            .just(Mutation.fetchUser(snapshot.userInfos)),
+            .just(.startTimer)
+          )
+        },
+
+      input.deleteAnimationComplete
+        .asObservable()
+        .withLatestFrom(shareState.map(\.user))
+        .compactMap { $0 }
+        .flatMap { user -> Observable<Mutation> in
+            .concat(.just(.removeSnapshot(user)),
+                    .just(.setScrollEvent(.scroll))
+            )
+        }
+    )
+  }
+
+  private func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+
+    let signalMutation = self.alertActionSignal
+      .withLatestFrom(state.compactMap(\.user)) { action, user in
+        return (action, user)
+      }
+      .flatMap { [weak self] (action, user) -> Observable<Mutation> in
+        guard let self else { return .empty() }
+        switch action {
+        case .cancel:
+          return .just(.startTimer)
+        case .block:
+          return .concat(
+            .just(.setScrollEvent(.scrollAfterDelete(user))),
+            self.fallingUseCase.block(userUUID: user.userUUID)
+              .asObservable()
+              .map { "차단하기가 완료되었습니다. 해당 사용자와\n서로 차단되며 설정에서 확인 가능합니다." }
+              .catch { .just($0.localizedDescription) }
+              .map { Mutation.toast($0) },
+            .just(.resetTimer)
+          )
+        case .report(let reason):
+          return .concat(
+            .just(.setScrollEvent(.scrollAfterDelete(user))),
+            self.fallingUseCase.report(userUUID: user.userUUID, reason: reason)
+              .asObservable()
+              .map { "유저 신고 완료" }
+              .catch { .just($0.localizedDescription) }
+              .map { Mutation.toast($0) },
+            .just(.resetTimer)
+          )
+        }
+      }
+
+    let timerShare = timer.currentTime
+      .share()
+
+    let timeOut = timerShare
+      .filter { $0 == .zero }
+      .flatMap { _ -> Observable<Mutation> in
+          .concat(
+            .just(.updateIndexPath(1))
+          )
+      }
+
+    let timeStateMutation = timerShare
+      .map { TimeState(rawValue: $0) }
+      .map { Mutation.setTimeState($0) }
+
+    return Observable.merge(mutation, signalMutation, timeStateMutation, timeOut)
+  }
+
+  private func reduce(state: State, mutation: Mutation) -> State {
+    var newState = state
+    switch mutation {
+    case let .fetchUser(users):
+      newState.snapshot = users
+      return newState
+    case let .updateIndexPath(offset):
+      if newState.snapshot.count - 1 > newState.index {
+        newState.index += offset
+        newState.scrollAction = .scroll(newState.indexPath)
+        timer.reset()
+        return newState
+      } else {
+        timer.pause()
+      }
+      return newState
+    case .selectAlert:
+      self.delegate?.invoke(.toReportBlockAlert(listener: self))
+      return newState
+    case let .toChatRoom(chatRoomIndex):
+      self.delegate?.invoke(.toChatRoom(chatRoomIndex: Int(chatRoomIndex) ?? 0))
+      return newState
+    case let .removeSnapshot(user):
+      newState.snapshot.removeAll(where: { $0 == user })
+      return newState
+    case let .toast(message):
+      newState.toast = message
+      return newState
+    case let .setScrollEvent(action):
+      switch action {
+      case .pause:
+        newState.scrollAction = .pause
+      case .scroll:
+        if let _ = newState.user {
+          newState.scrollAction = .scroll(newState.indexPath)
+        }
+        return newState
+      case .scrollAfterDelete(let user):
+        newState.scrollAction = .scrollAfterDelete(user)
+      }
+      return newState
+    case .stopTimer:
+      self.timer.pause()
+      return newState
+    case .startTimer:
+      self.timer.start()
+      return newState
+    case .resetTimer:
+      self.timer.reset()
+      return newState
+    case .setTimeState(let timeState):
+      newState.timeState = timeState
+      return newState
+    case .hidePause:
+      newState.shouldShowPause = false
+      return newState
+    case .showPause:
+      newState.shouldShowPause = true
+      return newState
+    }
+  }
+
+  public func transform(state: Observable<State>) -> Observable<State> {
+    state
+  }
+
+  public func pulse<Result>(_ transformToPulse: @escaping (State) throws -> Pulse<Result>) -> Observable<Result> {
+    state.map(transformToPulse).distinctUntilChanged(\.valueUpdatedCount).map(\.value)
   }
 }
 
@@ -172,5 +394,19 @@ extension FallingHomeViewModel: ReportAlertListener {
     case .cancel:
       self.alertActionSignal.accept(.cancel)
     }
+  }
+}
+
+
+extension Array {
+  @discardableResult
+  mutating func remove(safeAt index: Index) -> Element? {
+    guard self.count > index else { return nil }
+    return remove(at: index)
+  }
+
+  subscript(safe index: Index) -> Element? {
+    guard self.count > index else { return nil }
+    return self[index]
   }
 }

--- a/Projects/Features/Falling/Src/Model/TFTimer.swift
+++ b/Projects/Features/Falling/Src/Model/TFTimer.swift
@@ -1,0 +1,52 @@
+//
+//  TFTimer.swift
+//  Falling
+//
+//  Created by Kanghos on 6/28/24.
+//
+
+import Foundation
+
+import RxSwift
+import RxCocoa
+
+final class TFTimer {
+  private var disposable: Disposable? = nil
+
+  let currentTime = BehaviorRelay<Double>(value: 15.0)
+
+  private var startTime: Double
+  private let duration: Double
+
+  init(startTime: Double) {
+    self.duration = startTime
+    self.startTime = duration
+  }
+
+  func start() {
+    guard disposable == nil else { return }
+    if startTime < 0 { startTime = 15.0 }
+
+    disposable = Observable<Int>.interval(.milliseconds(10),
+                                          scheduler: MainScheduler.instance)
+    .take(Int(startTime * 100) + 1)
+    .map { [weak self] value in
+      guard let self = self else { return 0.0 }
+      return round((self.startTime * 100 - Double(value))) / 100
+    }
+    .bind(to: currentTime)
+  }
+
+  func pause() {
+    startTime = currentTime.value
+    disposable?.dispose()
+    disposable = nil
+  }
+
+  func reset() {
+    disposable?.dispose()
+    disposable = nil
+    startTime = duration
+    start()
+  }
+}

--- a/Projects/Features/Falling/Src/Model/TimeState.swift
+++ b/Projects/Features/Falling/Src/Model/TimeState.swift
@@ -1,0 +1,93 @@
+//
+//  TimeState.swift
+//  Falling
+//
+//  Created by Kanghos on 6/28/24.
+//
+
+import Foundation
+
+import DSKit
+
+enum TimeState {
+  case initial(value: Double) // 14~15
+  case five(value: Double)    // 12~14
+  case four(value: Double)    // 10~12
+  case three(value: Double)   // 8~10
+  case two(value: Double)     // 6~8
+  case one(value: Double)     // 4~6
+  case zero(value: Double)    // 2~4
+  case over(value: Double)    // 0~2
+  case none // Reject(싫어요) or Like(좋아요) or Delete(신고, 차단) user
+
+  init(rawValue: Double) {
+    switch rawValue {
+    case 14.0..<15.0: self = .initial(value: rawValue)
+    case 12.0..<14.0: self = .five(value: rawValue)
+    case 10.0..<12.0: self = .four(value: rawValue)
+    case 8.0..<10.0: self = .three(value: rawValue)
+    case 6.0..<8.0: self = .two(value: rawValue)
+    case 4.0..<6.0: self = .one(value: rawValue)
+    case 2.0..<4.0: self = .zero(value: rawValue)
+    case 0.0..<2.0: self = .over(value: rawValue)
+    default: self = .none
+    }
+  }
+
+  var timerTintColor: DSKitColors {
+    switch self {
+    case .zero, .five: return DSKitAsset.Color.primary500
+    case .four: return DSKitAsset.Color.thtOrange100
+    case .three: return DSKitAsset.Color.thtOrange200
+    case .two: return DSKitAsset.Color.thtOrange300
+    case .one: return DSKitAsset.Color.thtRed
+    default: return DSKitAsset.Color.neutral300
+    }
+  }
+
+  var progressBarColor: DSKitColors {
+    switch self {
+    case .five: return DSKitAsset.Color.primary500
+    case .four: return DSKitAsset.Color.thtOrange100
+    case .three: return DSKitAsset.Color.thtOrange200
+    case .two: return DSKitAsset.Color.thtOrange300
+    case .one: return DSKitAsset.Color.thtRed
+    default: return DSKitAsset.Color.neutral600
+    }
+  }
+
+  var isDotHidden: Bool {
+    switch self {
+    case .initial, .over, .none: return true
+    default: return false
+    }
+  }
+
+  var trackLayerStrokeColor: DSKitColors {
+    switch self {
+    case .initial, .over, .none: return DSKitAsset.Color.neutral300
+    default: return DSKitAsset.Color.clear
+    }
+  }
+
+  var getText: String {
+    switch self {
+    case .five: return "5"
+    case .four: return "4"
+    case .three: return "3"
+    case .two: return "2"
+    case .one: return "1"
+    case .zero: return "0"
+    default: return "-"
+    }
+  }
+
+  var getProgress: Double {
+    switch self {
+    case .initial: return 1
+    case .five(let value), .four(let value), .three(let value), .two(let value), .one(let value), .zero(let value), .over(let value):
+      return round((value / 2 - 2) / 5 * 1000) / 1000
+    default: return 0
+    }
+  }
+}

--- a/Projects/Features/Falling/Src/Subviews/CardCircleTimerView.swift
+++ b/Projects/Features/Falling/Src/Subviews/CardCircleTimerView.swift
@@ -11,6 +11,8 @@ import Core
 import DSKit
 
 final class CardCircleTimerView: TFBaseView {
+  private var gradientLayer: CAGradientLayer?
+
   lazy var timerLabel: UILabel = {
     let label = UILabel()
     label.font = .thtCaption1M
@@ -46,6 +48,7 @@ final class CardCircleTimerView: TFBaseView {
   private lazy var likeImageView: UIImageView = {
     let imageView = UIImageView()
     imageView.image = DSKitAsset.Image.Icons.cardLike.image.withTintColor(DSKitAsset.Color.error.color)
+    imageView.isHidden = true
     return imageView
   }()
   
@@ -58,6 +61,14 @@ final class CardCircleTimerView: TFBaseView {
     timerLabel.snp.makeConstraints {
       $0.centerX.centerY.equalToSuperview()
       $0.width.height.equalTo(16)
+    }
+
+    self.addSubview(likeImageView)
+
+    likeImageView.snp.makeConstraints {
+      $0.centerX.centerY.equalToSuperview()
+      $0.width.equalTo(8)
+      $0.height.equalTo(7)
     }
   }
   
@@ -87,34 +98,45 @@ final class CardCircleTimerView: TFBaseView {
                                clockwise: true)
     dotLayer.path = dotPath.cgPath
   }
-  
-  func addGradientLayer() {
-    self.addSubview(likeImageView)
-    
-    likeImageView.snp.makeConstraints {
-      $0.centerX.centerY.equalToSuperview()
-      $0.width.equalTo(8)
-      $0.height.equalTo(7)
+
+  func toggleCircleLayer(_ isHidden: Bool) {
+    addGradientLayer()
+
+    self.gradientLayer?.isHidden = isHidden
+    self.likeImageView.isHidden = isHidden
+  }
+
+  private func addGradientLayer() {
+    if let layer = gradientLayer {
+      return
+    } else {
+      let circleLayer = createGradientLayer()
+      self.gradientLayer = circleLayer
+      layer.addSublayer(circleLayer)
     }
-    
+  }
+
+  private func createGradientLayer() -> CAGradientLayer {
+
+
     let gradientLayer = CAGradientLayer()
-    
+
     gradientLayer.frame = self.bounds
-    
+
     gradientLayer.colors = [
       DSKitAsset.Color.LikeGradient.gradientFirst.color.cgColor,
       DSKitAsset.Color.LikeGradient.gradientSecond.color.cgColor,
       DSKitAsset.Color.LikeGradient.gradientThird.color.cgColor
     ]
-    
+
     gradientLayer.locations = [0.0, 0.5, 1.0]
-    
+
     gradientLayer.startPoint = CGPoint(x: 0.5, y: 1.0)
     gradientLayer.endPoint = CGPoint(x: 0.5, y: 0.0)
-    
+
     gradientLayer.mask = trackLayer
-    
-    layer.addSublayer(gradientLayer)
+
+    return gradientLayer
   }
   
   func bind(_ timeState: TimeState) {

--- a/Projects/Features/Falling/Src/Subviews/CardProgressView.swift
+++ b/Projects/Features/Falling/Src/Subviews/CardProgressView.swift
@@ -10,7 +10,9 @@ import UIKit
 import Core
 import DSKit
 
-final class CardProgressView: TFBaseView {
+final class CardProgressView: TFBaseView, Reusable {
+  private var likeLayer: CAGradientLayer?
+
   var progress: CGFloat = 0 {
     didSet {
       setNeedsDisplay()
@@ -44,23 +46,38 @@ final class CardProgressView: TFBaseView {
     self.layer.masksToBounds = true
     self.backgroundColor = DSKitAsset.Color.neutral600.color
   }
-  
-  func addGradientLayer() {
+
+  func toggleGradientLayer(_ isHidden: Bool) {
+    addGradientLayer()
+    self.likeLayer?.isHidden = isHidden
+  }
+
+  private func addGradientLayer() {
+    if let likeLayer {
+      return
+    }
+    let gradientLayer = createLikeLayer()
+    self.likeLayer = gradientLayer
+    layer.addSublayer(gradientLayer)
+  }
+
+  private func createLikeLayer() -> CAGradientLayer {
     let gradientLayer = CAGradientLayer()
-    
+    gradientLayer.name = Self.reuseIdentifier
+
     gradientLayer.frame = self.bounds
-    
+
     gradientLayer.colors = [
       DSKitAsset.Color.LikeGradient.gradientFirst.color.cgColor,
       DSKitAsset.Color.LikeGradient.gradientSecond.color.cgColor,
       DSKitAsset.Color.LikeGradient.gradientThird.color.cgColor
     ]
-    
+
     gradientLayer.locations = [0.0, 0.5, 1.0]
-    
+
     gradientLayer.startPoint = CGPoint(x: 0.0, y: 0.5)
     gradientLayer.endPoint = CGPoint(x: 1.0, y: 0.5)
-    
-    layer.addSublayer(gradientLayer)
+
+    return gradientLayer
   }
 }

--- a/Projects/Features/Falling/Src/Subviews/CardTimeView.swift
+++ b/Projects/Features/Falling/Src/Subviews/CardTimeView.swift
@@ -44,4 +44,58 @@ final class CardTimeView: TFBaseView {
       $0.height.equalTo(6)
     }
   }
+
+  func bind(_ timeState: TimeState) {
+    timerView.trackLayer.strokeColor = timeState.trackLayerStrokeColor.color.cgColor
+    timerView.strokeLayer.strokeColor = timeState.timerTintColor.color.cgColor
+    timerView.dotLayer.strokeColor = timeState.timerTintColor.color.cgColor
+    timerView.dotLayer.fillColor = timeState.timerTintColor.color.cgColor
+    timerView.timerLabel.textColor = timeState.timerTintColor.color
+    progressView.progressBarColor = timeState.progressBarColor.color
+
+    timerView.dotLayer.isHidden = timeState.isDotHidden
+
+    timerView.timerLabel.text = timeState.getText
+
+    progressView.progress = timeState.getProgress
+
+    // 소수점 3번 째자리까지 표시하면 오차가 발생해서 2번 째자리까지만 표시
+    let strokeEnd = round(timeState.getProgress * 100) / 100
+
+    timerView.dotLayer.position = dotPosition(progress: strokeEnd, rect: timerView.bounds, lineWidth: timerView.strokeLayer.lineWidth)
+
+    timerView.strokeLayer.strokeEnd = strokeEnd
+  }
+
+  private func dotPosition(progress: CGFloat, rect: CGRect, lineWidth: CGFloat) -> CGPoint {
+    let radius = CGFloat(rect.height / 2 - lineWidth / 2)
+
+    // 3 / 2 pi(정점 각도) -> - 1 / 2 pi(정점)
+    var angle = 2 * CGFloat.pi * progress - CGFloat.pi / 2 + CGFloat.pi / 10 // 두 원의 중점과 원점이 이루는 각도를 18도로 가정
+    if angle <= -CGFloat.pi / 2 || CGFloat.pi * 1.5 <= angle  {
+      angle = -CGFloat.pi / 2 // 정점 각도
+    }
+
+    let dotX = radius * cos(angle)
+    let dotY = radius * sin(angle)
+
+    let point = CGPoint(x: dotX, y: dotY)
+
+    return CGPoint(
+      x: rect.midX + point.x,
+      y: rect.midY + point.y
+    )
+  }
+
+  func showTimerGradient() {
+    progressView.toggleGradientLayer(false)
+    timerView.timerLabel.isHidden = true
+    timerView.toggleCircleLayer(false)
+  }
+
+  func hideTimerGradient() {
+    progressView.toggleGradientLayer(true)
+    timerView.timerLabel.isHidden = false
+    timerView.toggleCircleLayer(true)
+  }
 }

--- a/Projects/Features/Falling/Src/Subviews/Cell/FallingUserCollectionViewCell.swift
+++ b/Projects/Features/Falling/Src/Subviews/Cell/FallingUserCollectionViewCell.swift
@@ -17,53 +17,33 @@ struct FallingUserCollectionViewCellObserver {
 }
 
 final class FallingUserCollectionViewCell: TFBaseCollectionViewCell {
-  private var dataSource: DataSource!
-  
-  private var indexPath: IndexPath? {
-    guard let collectionView = self.superview as? UICollectionView,
-          let indexPath = collectionView.indexPath(for: self) else {
-      TFLogger.ui.error("indexPath 얻기 실패")
-      return nil
-    }
-    return indexPath
+  enum Action {
+    case likeTap
+    case rejectTap
+    case reportTap
+    case pause(Bool)
   }
-  
-  lazy var profileCollectionView: TFBaseCollectionView = {
-    let layout = UICollectionViewCompositionalLayout.horizontalListLayout()
-    
-    let collectionView = TFBaseCollectionView(
-      frame: .zero,
-      collectionViewLayout: layout
-    )
-    collectionView.backgroundColor = DSKitAsset.Color.DimColor.default.color
-    collectionView.layer.cornerRadius = 20
-    collectionView.isScrollEnabled = false
-    return collectionView
-  }()
-  
+
+  private var dataSource: DataSource!
+
+  lazy var carouselView = TFCarouselView().then {
+    $0.backgroundColor = DSKitAsset.Color.DimColor.default.color
+    $0.layer.cornerRadius = 20
+    $0.layer.masksToBounds = true
+    $0.carouselView.isScrollEnabled = false
+  }
+
   lazy var userInfoBoxView = UserInfoBoxView()
-  
   lazy var cardTimeView = CardTimeView()
-  
-  lazy var pauseView: PauseView = {
-    let pauseView = PauseView(
-      frame: CGRect(
-        x: 0,
-        y: 0,
-        width: (UIWindow.keyWindow?.bounds.width ?? .zero) - 32,
-        height: ((UIWindow.keyWindow?.bounds.width ?? .zero) - 32) * 1.64
-      )
-    )
-    return pauseView
-  }()
-  
+  lazy var pauseView = PauseView()
+
   lazy var lottieView: LottieAnimationView = {
     let lottieAnimationView = LottieAnimationView()
     lottieAnimationView.isHidden = true
     lottieAnimationView.contentMode = .scaleAspectFit
     return lottieAnimationView
   }()
-  
+
   lazy var userInfoView: UserInfoView = {
     let view = UserInfoView()
     view.layer.cornerRadius = 20
@@ -72,198 +52,122 @@ final class FallingUserCollectionViewCell: TFBaseCollectionViewCell {
     view.isHidden = true
     return view
   }()
-  
+
+  // MARK: State
+  let lottieRelay = PublishRelay<AnimationAsset>()
+  let userDetailInfoRelay = PublishRelay<Bool>()
+  let pauseViewRelay = PublishRelay<Bool>()
+  let dimViewRelay = PublishRelay<Bool>()
+  let activateCardSubject = BehaviorSubject(value: false)
+
+  var isActivate = false
+
   override func makeUI() {
     self.layer.cornerRadius = 20
-    
-    self.contentView.addSubviews([profileCollectionView, cardTimeView, userInfoBoxView, userInfoBoxView, userInfoView, lottieView, pauseView])
-    
-    profileCollectionView.snp.makeConstraints {
+    self.layer.masksToBounds = true
+
+    self.contentView.addSubviews([carouselView, cardTimeView, userInfoBoxView, userInfoBoxView, userInfoView, lottieView, pauseView])
+
+    carouselView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
-    
+
     self.cardTimeView.snp.makeConstraints {
-      $0.top.leading.trailing.equalTo(profileCollectionView).inset(12)
+      $0.top.leading.trailing.equalTo(carouselView).inset(12)
       $0.height.equalTo(32)
     }
-    
+
     self.userInfoBoxView.snp.makeConstraints {
       $0.height.equalTo(145)
       $0.leading.trailing.equalToSuperview().inset(16)
       $0.bottom.equalToSuperview().inset(12)
     }
-    
+
     userInfoView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview().inset(10)
       $0.height.equalTo(300)
       $0.bottom.equalTo(userInfoBoxView.snp.top).offset(-8)
     }
-    
+
     self.pauseView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
-    
+
     self.lottieView.snp.makeConstraints {
       $0.center.equalToSuperview()
       $0.width.height.equalTo(188) // TODO: 사이즈 수정 예정
     }
-    
-    self.profileCollectionView.showDimView()
-    
+
     self.setDataSource()
+
+    bind()
   }
-  
+
   override func prepareForReuse() {
     super.prepareForReuse()
-    disposeBag = DisposeBag()
+
+    bind()
+    // MARK: Init
+    cardTimeView.bind(.none)
+    cardTimeView.hideTimerGradient()
+    userInfoView.isHidden = true
   }
-  
-  func bind<O>(
-    _ viewModel: FallingUserCollectionViewCellModel,
-    timerActiveTrigger: Driver<Bool>,
-    timeOverSubject: PublishSubject<AnimationAction>,
-    profileDoubleTapTriggerObserver: PublishSubject<Void>,
-    fallingCellButtonAction: O,
-    reportButtonTapTriggerObserver: PublishSubject<Void>,
-    deleteCellTrigger: Driver<Void>
-  ) where O: ObserverType, O.Element == FallingCellButtonAction {
-    let infoButtonTapTrigger = userInfoBoxView.infoButton.rx.tap.asDriver()
-    
-    let rejectButtonTapTrigger = userInfoBoxView.rejectButton.rx.tap.asDriver()
-    
-    let likeButtonTapTrigger = userInfoBoxView.likeButton.rx.tap.asDriver()
-    
-    let reportButtonTapTrigger = userInfoView.reportButton.rx.tap.asDriver()
-    
-    let showUserInfoTrigger = Driver.merge(infoButtonTapTrigger, reportButtonTapTrigger).scan(true) { value, _ in
-      return !value
-    }
-    
-    let input = FallingUserCollectionViewCellModel.Input(
-      timerActiveTrigger: timerActiveTrigger,
-      showUserInfoTrigger: showUserInfoTrigger,
-      rejectButtonTapTrigger: rejectButtonTapTrigger,
-      likeButtonTapTrigger: likeButtonTapTrigger,
-      reportButtonTapTrigger: reportButtonTapTrigger,
-      deleteCellTrigger: deleteCellTrigger
-    )
-    
-    let output = viewModel
-      .transform(input: input)
-    
-    output.user
-      .drive(self.rx.user)
+
+  func bind() {
+    let lottieSignal: Signal<AnimationAsset> = lottieRelay.asSignal()
+    let userDetailInfoSignal: Signal<Bool> = userDetailInfoRelay.asSignal()
+    let pauseViewSignal = pauseViewRelay.asSignal()
+    let dimViewSignal = dimViewRelay.asSignal()
+
+    pauseViewSignal
+      .emit(to: pauseView.rx.isPauseViewHidden)
       .disposed(by: disposeBag)
-    
-    output.timeState
-      .drive(self.rx.timeState)
-      .disposed(by: self.disposeBag)
-    
-    output.timeZero
-      .drive(timeOverSubject)
-      .disposed(by: disposeBag)
-    
-    output.timerActiveAction
-      .drive(self.rx.timerActiveAction)
-      .disposed(by: disposeBag)
-    
-    let profileDoubleTapTrigger = self.profileCollectionView.rx
-      .tapGesture(configuration: { gestureRecognizer, delegate in
-        gestureRecognizer.numberOfTapsRequired = 2
-      })
-      .when(.recognized)
-      .mapToVoid()
-      .asDriverOnErrorJustEmpty()
-    
-    let pauseViewDoubleTapTrigger = self.pauseView.rx
-      .tapGesture(configuration: { gestureRecognizer, delegate in
-        gestureRecognizer.numberOfTapsRequired = 2
-      })
-      .when(.recognized)
-      .mapToVoid()
-      .asDriverOnErrorJustEmpty()
-    
-    Driver.merge(profileDoubleTapTrigger, pauseViewDoubleTapTrigger)
-      .map { _ in }
-      .drive(profileDoubleTapTriggerObserver)
-      .disposed(by: disposeBag)
-    
-    output.showUserInfoAction
-      .drive(userInfoView.rx.isHidden)
-      .disposed(by: disposeBag)
-      
-    output.rejectButtonAction
-      .throttle(.milliseconds(5000), latest: false)
-      .compactMap { [weak self] _ in self?.indexPath }
-      .map { FallingCellButtonAction.reject($0) }
-      .drive(with: self) { owner, action in
-        fallingCellButtonAction.onNext(action)
-        owner.lottieView.snp.updateConstraints { $0.width.height.equalTo(188) }
-        owner.lottieView.animation = AnimationAsset.unlike.animation
+
+    dimViewSignal
+      .emit(with: self) { owner, isHidden in
+        isHidden
+        ? owner.carouselView.hiddenDimView()
+        : owner.carouselView.showDimView()
+      }.disposed(by: disposeBag)
+
+    lottieSignal
+      .emit(with: self) { owner, lottie in
+        owner.lottieView.animation = lottie.animation
         owner.lottieView.isHidden = false
-        owner.lottieView.play()
-      }
+        owner.lottieView.play { completed in
+          owner.lottieView.isHidden = true
+        }
+      }.disposed(by: disposeBag)
+
+    activateCardSubject.asSignal(onErrorSignalWith: .empty())
+      .emit(to: self.rx.isDimViewHidden)
       .disposed(by: disposeBag)
-    
-    output.likeButtonAction
-      .throttle(.milliseconds(5000), latest: false)
-      .compactMap { [weak self] _ in self?.indexPath }
-      .map { FallingCellButtonAction.like($0) }
-      .drive(with: self) { owner, action in
-        fallingCellButtonAction.onNext(action)
-        owner.lottieView.snp.updateConstraints { $0.width.height.equalTo(200) }
-        owner.lottieView.animation = AnimationAsset.likeHeart.animation
-        owner.lottieView.isHidden = false
-        owner.lottieView.play()
-        owner.cardTimeView.progressView.addGradientLayer()
-        owner.cardTimeView.timerView.timerLabel.isHidden = true
-        owner.cardTimeView.timerView.addGradientLayer()
-      }
+
+    userDetailInfoSignal
+      .emit(to: userInfoView.rx.isHidden)
       .disposed(by: disposeBag)
-    
-    output.reportButtonAction
-      .drive(with: self) { owner, _ in
-        reportButtonTapTriggerObserver.onNext(())
-        owner.pauseView.ImageContainerView.isHidden = true
-        owner.pauseView.titleLabel.isHidden = true
-      }
-      .disposed(by: disposeBag)
-    
-    output.deleteCellAction
-      .drive(with: self) { owner, _ in
-        owner.pauseView.isHidden = true
-        owner.profileCollectionView.showDimView()
-      }
+
+    self.userInfoBoxView.infoButton.rx.tap
+      .throttle(.milliseconds(300), latest: false, scheduler: MainScheduler.instance)
+      .scan(true) { latest, _ in !latest }
+      .bind(to: userDetailInfoRelay)
       .disposed(by: disposeBag)
   }
-  
+
   func bind(userProfilePhotos: [UserProfilePhoto]) {
     var snapshot = Snapshot()
     snapshot.appendSections([.profile])
     snapshot.appendItems(userProfilePhotos)
     self.dataSource.apply(snapshot)
-    
-    userInfoBoxView.pageControl.numberOfPages = userProfilePhotos.count
+
+    self.carouselView.pageControl.numberOfPages = userProfilePhotos.count
   }
-  
-  func dotPosition(progress: CGFloat, rect: CGRect) -> CGPoint {
-    let radius = CGFloat(rect.height / 2 - cardTimeView.timerView.strokeLayer.lineWidth / 2)
-      
-    // 3 / 2 pi(정점 각도) -> - 1 / 2 pi(정점)
-    var angle = 2 * CGFloat.pi * progress - CGFloat.pi / 2 + CGFloat.pi / 10 // 두 원의 중점과 원점이 이루는 각도를 18도로 가정
-    if angle <= -CGFloat.pi / 2 || CGFloat.pi * 1.5 <= angle  {
-      angle = -CGFloat.pi / 2 // 정점 각도
-    }
-    
-    let dotX = radius * cos(angle)
-    let dotY = radius * sin(angle)
-    
-    let point = CGPoint(x: dotX, y: dotY)
-    
-    return CGPoint(
-      x: rect.midX + point.x,
-      y: rect.midY + point.y
-    )
+}
+
+extension FallingUserCollectionViewCell {
+  var activateState: Observable<Bool> {
+    self.activateCardSubject.share()
+      .debug("active state")
   }
 }
 
@@ -271,43 +175,121 @@ extension FallingUserCollectionViewCell {
   typealias Model = UserProfilePhoto
   typealias DataSource = UICollectionViewDiffableDataSource<FallingProfileSection, Model>
   typealias Snapshot = NSDiffableDataSourceSnapshot<FallingProfileSection, Model>
-  
+
   func setDataSource() {
     let profileCellRegistration = UICollectionView.CellRegistration<ProfileCollectionViewCell, Model> { cell, indexPath, item in
       cell.bind(imageURL: item.url)
     }
-    
-    self.dataSource = UICollectionViewDiffableDataSource(collectionView: profileCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+
+    self.dataSource = UICollectionViewDiffableDataSource(collectionView: carouselView.carouselView, cellProvider: { collectionView, indexPath, itemIdentifier in
       return collectionView.dequeueConfiguredReusableCell(using: profileCellRegistration, for: indexPath, item: itemIdentifier)
     })
   }
 }
 
+// MARK: ControlEvent
+
 extension Reactive where Base: FallingUserCollectionViewCell {
+
+  var likeBtnTap: ControlEvent<Base.Action> {
+    let source: Observable<Base.Action> = self.base.userInfoBoxView.likeButton.rx.tap
+      .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.instance)
+      .withLatestFrom(self.base.activateCardSubject)
+      .flatMap { isActivate -> Observable<Base.Action> in
+        return isActivate
+        ? .just(Base.Action.likeTap)
+        : .empty()
+      }
+      .do { [weak base = self.base] _ in
+        base?.lottieRelay.accept(.likeHeart)
+        base?.cardTimeView.bind(.none)
+        base?.cardTimeView.showTimerGradient()
+      }
+    return ControlEvent(events: source)
+  }
+
+  var rejectBtnTap: ControlEvent<Base.Action> {
+    let source: Observable<Base.Action> = self.base.userInfoBoxView.rejectButton.rx.tap
+      .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.instance)
+      .withLatestFrom(self.base.activateCardSubject)
+      .flatMap { isActivate -> Observable<Base.Action> in
+        return isActivate
+        ? .just(Base.Action.rejectTap)
+        : .empty()
+      }
+      .do { [weak base = self.base] _ in
+        base?.lottieRelay.accept(.unlike)
+        base?.cardTimeView.bind(.none)
+        base?.cardTimeView.hideTimerGradient()
+      }
+    return ControlEvent(events: source)
+  }
+
+  var reportBtnTap: ControlEvent<Base.Action> {
+    let source: Observable<Base.Action> = self.base.userInfoView.reportButton.rx.tap
+      .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.instance)
+      .withLatestFrom(self.base.activateCardSubject)
+      .flatMap { isActivate -> Observable<Base.Action> in
+        return isActivate
+        ? .just(Base.Action.reportTap)
+        : .empty()
+      }
+      .do(onNext: { [weak base = self.base] _ in
+        base?.pauseView.showBlurView()
+      })
+
+    return ControlEvent(events: source)
+  }
+
+  var cardDoubleTap: ControlEvent<Base.Action> {
+    let source = self.base.carouselView.carouselView.rx
+      .tapGesture(configuration: { gestureRecognizer, delegate in
+        gestureRecognizer.numberOfTapsRequired = 2
+      })
+      .when(.recognized)
+      .withLatestFrom(self.base.activateCardSubject)
+      .flatMap { isActivate -> Observable<Base.Action> in
+        return isActivate
+        ? .just(.pause(true))
+        : .empty()
+      }
+      .do(onNext: { [weak base = self.base] _ in
+        base?.pauseViewRelay.accept(false)
+      })
+
+    return ControlEvent(events: source)
+  }
+
+  var pauseDoubleTap: ControlEvent<Base.Action> {
+    let source = self.base.pauseView.rx
+      .tapGesture(configuration: { gestureRecognizer, delegate in
+        gestureRecognizer.numberOfTapsRequired = 2
+      })
+      .when(.recognized)
+      .withLatestFrom(self.base.activateCardSubject)
+      .flatMap { isActivate -> Observable<Base.Action> in
+        return isActivate
+        ? .just(.pause(false))
+        : .empty()
+      }
+      .do(onNext: { [weak base = self.base] _ in
+        base?.pauseViewRelay.accept(true)
+      })
+
+    return ControlEvent(events: source)
+  }
+}
+
+// MARK: Binder
+
+extension Reactive where Base == FallingUserCollectionViewCell {
+
   var timeState: Binder<TimeState> {
     return Binder(self.base) { (base, timeState) in
-      base.cardTimeView.timerView.trackLayer.strokeColor = timeState.trackLayerStrokeColor.color.cgColor
-      base.cardTimeView.timerView.strokeLayer.strokeColor = timeState.timerTintColor.color.cgColor
-      base.cardTimeView.timerView.dotLayer.strokeColor = timeState.timerTintColor.color.cgColor
-      base.cardTimeView.timerView.dotLayer.fillColor = timeState.timerTintColor.color.cgColor
-      base.cardTimeView.timerView.timerLabel.textColor = timeState.timerTintColor.color
-      base.cardTimeView.progressView.progressBarColor = timeState.progressBarColor.color
-      
-      base.cardTimeView.timerView.dotLayer.isHidden = timeState.isDotHidden
-      
-      base.cardTimeView.timerView.timerLabel.text = timeState.getText
-      
-      base.cardTimeView.progressView.progress = timeState.getProgress
-      
-      // 소수점 3번 째자리까지 표시하면 오차가 발생해서 2번 째자리까지만 표시
-      let strokeEnd = round(timeState.getProgress * 100) / 100
-      
-      base.cardTimeView.timerView.dotLayer.position = base.dotPosition(progress: strokeEnd, rect: base.cardTimeView.timerView.bounds)
-      
-      base.cardTimeView.timerView.strokeLayer.strokeEnd = strokeEnd
+      base.cardTimeView.bind(timeState)
     }
   }
-  
+
   var user: Binder<FallingUser> {
     return Binder(self.base) { base, user in
       base.bind(userProfilePhotos: user.userProfilePhotos)
@@ -315,17 +297,9 @@ extension Reactive where Base: FallingUserCollectionViewCell {
       base.userInfoView.bind(user)
     }
   }
-  
-  var timerActiveAction: Binder<Bool> {
-    return Binder(self.base) { base, value in
-      if value {
-        base.profileCollectionView.hiddenDimView()
-        base.pauseView.isHidden = true
-      } else {
-        base.pauseView.ImageContainerView.isHidden = false
-        base.pauseView.titleLabel.isHidden = false
-        base.pauseView.isHidden = false
-      }
+  var isDimViewHidden: Binder<Bool> {
+    return Binder(self.base) { (base, isHidden) in
+      isHidden ? base.carouselView.hiddenDimView() : base.carouselView.showDimView()
     }
   }
 }

--- a/Projects/Features/Falling/Src/Subviews/Cell/FallinguserCollectionViewCellModel.swift
+++ b/Projects/Features/Falling/Src/Subviews/Cell/FallinguserCollectionViewCellModel.swift
@@ -1,213 +1,105 @@
+////
+////  FallingUserCollectionViewCellModel.swift
+////  FallingInterface
+////
+////  Created by SeungMin on 1/11/24.
+////
 //
-//  FallingUserCollectionViewCellModel.swift
-//  FallingInterface
+//import Foundation
 //
-//  Created by SeungMin on 1/11/24.
+//import Core
+//import FallingInterface
+//import DSKit
+//
 //
 
-import Foundation
-
-import Core
-import FallingInterface
-import DSKit
-
-enum TimeState {
-  case initial(value: Double) // 14~15
-  case five(value: Double)    // 12~14
-  case four(value: Double)    // 10~12
-  case three(value: Double)   // 8~10
-  case two(value: Double)     // 6~8
-  case one(value: Double)     // 4~6
-  case zero(value: Double)    // 2~4
-  case over(value: Double)    // 0~2
-  case none // Reject(싫어요) or Like(좋아요) or Delete(신고, 차단) user
-  
-  init(rawValue: Double) {
-    switch rawValue {
-    case 14.0..<15.0: self = .initial(value: rawValue)
-    case 12.0..<14.0: self = .five(value: rawValue)
-    case 10.0..<12.0: self = .four(value: rawValue)
-    case 8.0..<10.0: self = .three(value: rawValue)
-    case 6.0..<8.0: self = .two(value: rawValue)
-    case 4.0..<6.0: self = .one(value: rawValue)
-    case 2.0..<4.0: self = .zero(value: rawValue)
-    case 0.0..<2.0: self = .over(value: rawValue)
-    default: self = .none
-    }
-  }
-  
-  var timerTintColor: DSKitColors {
-    switch self {
-    case .zero, .five: return DSKitAsset.Color.primary500
-    case .four: return DSKitAsset.Color.thtOrange100
-    case .three: return DSKitAsset.Color.thtOrange200
-    case .two: return DSKitAsset.Color.thtOrange300
-    case .one: return DSKitAsset.Color.thtRed
-    default: return DSKitAsset.Color.neutral300
-    }
-  }
-  
-  var progressBarColor: DSKitColors {
-    switch self {
-    case .five: return DSKitAsset.Color.primary500
-    case .four: return DSKitAsset.Color.thtOrange100
-    case .three: return DSKitAsset.Color.thtOrange200
-    case .two: return DSKitAsset.Color.thtOrange300
-    case .one: return DSKitAsset.Color.thtRed
-    default: return DSKitAsset.Color.neutral600
-    }
-  }
-  
-  var isDotHidden: Bool {
-    switch self {
-    case .initial, .over, .none: return true
-    default: return false
-    }
-  }
-  
-  var trackLayerStrokeColor: DSKitColors {
-    switch self {
-    case .initial, .over, .none: return DSKitAsset.Color.neutral300
-    default: return DSKitAsset.Color.clear
-    }
-  }
-  
-  var getText: String {
-    switch self {
-    case .five: return "5"
-    case .four: return "4"
-    case .three: return "3"
-    case .two: return "2"
-    case .one: return "1"
-    case .zero: return "0"
-    default: return "-"
-    }
-  }
-  
-  var getProgress: Double {
-    switch self {
-    case .initial: return 1
-    case .five(let value), .four(let value), .three(let value), .two(let value), .one(let value), .zero(let value), .over(let value):
-      return round((value / 2 - 2) / 5 * 1000) / 1000
-    default: return 0
-    }
-  }
-}
-
-final private class Timer {
-  private var disposable: Disposable? = nil
-  
-  let currentTime = BehaviorRelay<Double>(value: 15.0)
-  private var startTime: Double
-  
-  init(startTime: Double) {
-    self.startTime = startTime
-  }
-  
-  func start() {
-    guard disposable == nil else { return }
-    if startTime < 0 { startTime = 15.0 }
-    
-    disposable = Observable<Int>.interval(.milliseconds(10),
-                                          scheduler: MainScheduler.instance)
-    .take(Int(startTime * 100) + 1)
-    .map { [weak self] value in
-      guard let self = self else { return 0.0 }
-      return round((self.startTime * 100 - Double(value))) / 100
-    }
-    .debug()
-    .bind(to: currentTime)
-  }
-  
-  func pause() {
-    startTime = currentTime.value
-    disposable?.dispose()
-    disposable = nil
-  }
-}
-
-final class FallingUserCollectionViewCellModel: ViewModelType {
-  let userDomain: FallingUser
-  
-  init(userDomain: FallingUser) {
-    self.userDomain = userDomain
-  }
-  
-  var disposeBag: DisposeBag = DisposeBag()
-  
-  struct Input {
-    let timerActiveTrigger: Driver<Bool>
-    let showUserInfoTrigger: Driver<Bool>
-    let rejectButtonTapTrigger: Driver<Void>
-    let likeButtonTapTrigger: Driver<Void>
-    let reportButtonTapTrigger: Driver<Void>
-    let deleteCellTrigger: Driver<Void>
-  }
-  
-  struct Output {
-    let user: Driver<FallingUser>
-    let timeState: Driver<TimeState>
-    let timerActiveAction: Driver<Bool>
-    let timeZero: Driver<AnimationAction>
-    let rejectButtonAction: Driver<Void>
-    let likeButtonAction: Driver<Void>
-    let showUserInfoAction: Driver<Bool>
-    let reportButtonAction: Driver<Void>
-    let deleteCellAction: Driver<Void>
-  }
-  
-  func transform(input: Input) -> Output {
-    let timer = Timer(startTime: 15.0)
-    let time = timer.currentTime.asDriver(onErrorJustReturn: 0.0)
-    let user = Driver.just(userDomain)
-    
-    let timeState = Driver.merge(
-      input.rejectButtonTapTrigger.map { TimeState.none },
-      input.likeButtonTapTrigger.map { TimeState.none },
-      input.deleteCellTrigger.map { TimeState.none },
-      time.map { TimeState(rawValue: $0) }
-    )
-    
-    let timerActiveAction = input.timerActiveTrigger
-      .do { value in
-        if !value {
-          timer.pause()
-        } else {
-          timer.start()
-        }
-      }
-    
-    let timeZero = time.filter { $0 == 0.0 }.flatMapLatest { _ in Driver.just(AnimationAction.scroll) }
-    
-    let rejectButtonAction = input.rejectButtonTapTrigger
-      .do { _ in
-        timer.pause()
-      }
-    
-    let likeButtonAction = input.likeButtonTapTrigger
-      .do { _ in
-        timer.pause()
-      }
-    
-    let showUserInfoAction = input.showUserInfoTrigger
-    
-    let reportButtonTapTrigger = input.reportButtonTapTrigger
-    
-    let deleteCellAction = input.deleteCellTrigger
-      .do(onNext: {
-        timer.pause()
-      })
-    
-    return Output(
-      user: user,
-      timeState: timeState,
-      timerActiveAction: timerActiveAction,
-      timeZero: timeZero,
-      rejectButtonAction: rejectButtonAction,
-      likeButtonAction: likeButtonAction,
-      showUserInfoAction: showUserInfoAction,
-      reportButtonAction: reportButtonTapTrigger,
-      deleteCellAction: deleteCellAction
-    )
-  }
-}
+//
+//final class FallingUserCollectionViewCellModel: ViewModelType {
+//  let userDomain: FallingUser
+//  
+//  init(userDomain: FallingUser) {
+//    self.userDomain = userDomain
+//  }
+//  
+//  var disposeBag: DisposeBag = DisposeBag()
+//  
+//  struct Input {
+//    let timerActiveTrigger: Driver<Bool>
+//    let showUserInfoTrigger: Driver<Bool>
+//    let rejectButtonTapTrigger: Driver<Void>
+//    let likeButtonTapTrigger: Driver<Void>
+//    let reportButtonTapTrigger: Driver<Void>
+//    let deleteCellTrigger: Driver<Void>
+//  }
+//  
+//  struct Output {
+//    let user: Driver<FallingUser>
+//    let timeState: Driver<TimeState>
+//    let timerActiveAction: Driver<Bool>
+//    let timeZero: Driver<AnimationAction>
+//    let rejectButtonAction: Driver<Void>
+//    let likeButtonAction: Driver<Void>
+//    let showUserInfoAction: Driver<Bool>
+//    let reportButtonAction: Driver<Void>
+//    let deleteCellAction: Driver<Void>
+//  }
+//  
+//  func transform(input: Input) -> Output {
+//    let timer = Timer(startTime: 15.0)
+//    let time = timer.currentTime.asDriver(onErrorJustReturn: 0.0)
+//    let user = Driver.just(userDomain)
+//    
+//    let timeState = Driver.merge(
+//      input.rejectButtonTapTrigger.map { TimeState.none },
+//      input.likeButtonTapTrigger.map { TimeState.none },
+//      input.deleteCellTrigger.map { TimeState.none },
+//      time.map { TimeState(rawValue: $0) }
+//    )
+//    
+//    let timerActiveAction = input.timerActiveTrigger
+//      .withLatestFrom(user.map(\.username)) {
+//        print($1)
+//        return $0
+//      }
+//      .do { [weak self] value in
+//        if !value {
+//          timer.pause()
+//        } else {
+//          timer.start()
+//        }
+//      }
+//    
+//    let timeZero = time.filter { $0 == 0.0 }.flatMapLatest { _ in Driver.just(AnimationAction.scroll) }
+//    
+//    let rejectButtonAction = input.rejectButtonTapTrigger
+//      .do { _ in
+//        timer.pause()
+//      }
+//    
+//    let likeButtonAction = input.likeButtonTapTrigger
+//      .do { _ in
+//        timer.pause()
+//      }
+//    
+//    let showUserInfoAction = input.showUserInfoTrigger
+//    
+//    let reportButtonTapTrigger = input.reportButtonTapTrigger
+//    
+//    let deleteCellAction = input.deleteCellTrigger
+//      .do(onNext: {
+//        timer.pause()
+//      })
+//    
+//    return Output(
+//      user: user,
+//      timeState: timeState,
+//      timerActiveAction: timerActiveAction,
+//      timeZero: timeZero,
+//      rejectButtonAction: rejectButtonAction,
+//      likeButtonAction: likeButtonAction,
+//      showUserInfoAction: showUserInfoAction,
+//      reportButtonAction: reportButtonTapTrigger,
+//      deleteCellAction: deleteCellAction
+//    )
+//  }
+//}

--- a/Projects/Features/Falling/Src/Subviews/PauseView.swift
+++ b/Projects/Features/Falling/Src/Subviews/PauseView.swift
@@ -68,7 +68,11 @@ open class PauseView: TFBaseView {
       ImageContainerView,
       titleLabel
     ])
-    
+
+    blurView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
     ImageContainerView.addSubview(pauseImageView)
     
     ImageContainerView.snp.makeConstraints {
@@ -81,6 +85,34 @@ open class PauseView: TFBaseView {
       
     stackView.snp.makeConstraints {
       $0.centerX.centerY.equalToSuperview()
+    }
+  }
+
+  public func showBlurView() {
+    stackView.isHidden = true
+    self.isHidden = false
+  }
+
+  public func hide() {
+    self.isHidden = true
+  }
+
+  public func showPauseView() {
+    stackView.isHidden = false
+    self.isHidden = false
+  }
+}
+
+extension Reactive where Base: PauseView {
+  var isDimViewHidden: Binder<Bool> {
+    return Binder(self.base) { (base, isHidden) in
+      isHidden ? base.hide() : base.showBlurView()
+    }
+  }
+
+  var isPauseViewHidden: Binder<Bool> {
+    return Binder(self.base) { (base, isHidden) in
+      isHidden ? base.hide() : base.showPauseView()
     }
   }
 }

--- a/Projects/Features/Falling/Src/Subviews/TFCarouselView.swift
+++ b/Projects/Features/Falling/Src/Subviews/TFCarouselView.swift
@@ -1,0 +1,53 @@
+//
+//  TFCarouselView.swift
+//  Falling
+//
+//  Created by Kanghos on 6/29/24.
+//
+
+import Foundation
+
+import UIKit
+
+import DSKit
+
+final class TFCarouselView: TFBaseView {
+
+  lazy var carouselView = TFBaseCollectionView(frame: .zero, collectionViewLayout: createLayout())
+
+  lazy var pageControl = UIPageControl().then {
+    $0.currentPageIndicatorTintColor = .black
+    $0.pageIndicatorTintColor = .gray
+  }
+
+  func register<T: UICollectionViewCell>(cellType: T.Type) {
+    carouselView.register(cellType: cellType.self)
+  }
+
+  override func makeUI() {
+    carouselView.isScrollEnabled = false
+
+    addSubviews(carouselView, pageControl)
+
+    carouselView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+
+    pageControl.snp.makeConstraints {
+      $0.centerX.equalToSuperview()
+      $0.height.equalTo(30)
+      $0.bottom.equalToSuperview().inset(10)
+    }
+  }
+
+  // MARK: pageControl
+  func createLayout() -> UICollectionViewLayout {
+    let sectionLayout: NSCollectionLayoutSection = .horizontalListSection()
+    sectionLayout.visibleItemsInvalidationHandler = { [weak self] (items, offset, environment) in
+      guard let self = self else { return }
+      let index = Int(offset.x / self.carouselView.frame.width)
+      self.pageControl.currentPage = index
+    }
+    return UICollectionViewCompositionalLayout(section: sectionLayout)
+  }
+}

--- a/Projects/Features/Falling/Src/Subviews/UserInfoBoxView.swift
+++ b/Projects/Features/Falling/Src/Subviews/UserInfoBoxView.swift
@@ -11,12 +11,12 @@ import DSKit
 import FallingInterface
 
 final class UserInfoBoxView: TFBaseView {
-  lazy var pageControl: UIPageControl = {
-    let pageControl = UIPageControl()
-    pageControl.pageIndicatorTintColor = DSKitAsset.Color.neutral50.color
-    pageControl.currentPageIndicatorTintColor = DSKitAsset.Color.neutral300.color
-    return pageControl
-  }()
+//  lazy var pageControl: UIPageControl = {
+//    let pageControl = UIPageControl()
+//    pageControl.pageIndicatorTintColor = DSKitAsset.Color.neutral50.color
+//    pageControl.currentPageIndicatorTintColor = DSKitAsset.Color.neutral300.color
+//    return pageControl
+//  }()
   
   private lazy var titleLabel: UILabel = {
     let label = UILabel()
@@ -78,8 +78,8 @@ final class UserInfoBoxView: TFBaseView {
     
     labelStackView.addArrangedSubviews([titleLabel, adressStackView])
     
-    addSubviews([labelStackView, buttonStackView, pageControl])
-    
+    addSubviews([labelStackView, buttonStackView])// , pageControl])
+
     labelStackView.snp.makeConstraints {
       $0.top.leading.trailing.equalToSuperview()
     }
@@ -101,12 +101,12 @@ final class UserInfoBoxView: TFBaseView {
       $0.width.equalTo(92).priority(.low)
     }
     
-    pageControl.snp.makeConstraints {
-      $0.top.equalTo(buttonStackView.snp.bottom).offset(14)
-      $0.centerX.equalToSuperview()
-      $0.height.equalTo(6)
-      $0.width.greaterThanOrEqualTo(38)
-    }
+//    pageControl.snp.makeConstraints {
+//      $0.top.equalTo(buttonStackView.snp.bottom).offset(14)
+//      $0.centerX.equalToSuperview()
+//      $0.height.equalTo(6)
+//      $0.width.greaterThanOrEqualTo(38)
+//    }
   }
   
   func bind(_ viewModel: FallingUser) {

--- a/Projects/Features/SignUp/Src/SignUpRoot/SignUpComplete/SignUpCompleteView.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/SignUpComplete/SignUpCompleteView.swift
@@ -17,52 +17,33 @@ final class SignUpCompleteView: TFBaseView {
   lazy var titleLabel: UILabel = UILabel().then {
     $0.text = "환영해요! 💫\n모든 준비가 끝났어요"
     $0.textColor = DSKitAsset.Color.neutral50.color
-    $0.font = .thtH2B
+    $0.font = .thtH3B
     $0.numberOfLines = 0
     $0.textAlignment = .center
   }
-
-  private lazy var conicGradient: CAGradientLayer = {
-    let gradient = CAGradientLayer()
-    gradient.type = .conic
-    gradient.colors = [
-      DSKitAsset.Color.primary500.color.cgColor,
-      DSKitAsset.Color.thtOrange400.color.cgColor
-    ]
-    gradient.locations = [0]
-
-    // startPoint: 원의 중심, endPoint: 첫 번째 색상과 마지막 색상이 결합되는 지점
-    // (0,0)우측하단, (1,1)은 (0,0)에서 한바퀴 돌은 지점
-    gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
-    gradient.endPoint = CGPoint(x: 0.5, y: 1)
-    return gradient
-  }()
-
-  private lazy var gradientView = UIView().then {
-    $0.backgroundColor = .green
-    $0.layer.addSublayer(conicGradient)
-    $0.layer.cornerRadius = 32
-    $0.clipsToBounds = true
-  }
-
+  
   lazy var descLabel = UILabel().then {
     $0.text = "폴링에 한 번 빠져 보시겠어요"
-    $0.font = .thtSubTitle1R
+    $0.font = .thtH5R
     $0.textColor = DSKitAsset.Color.neutral400.color
     $0.textAlignment = .center
     $0.numberOfLines = 2
   }
+  private lazy var gradientView = TFShimmerGradientView()
 
   lazy var imageView = UIImageView().then {
     $0.image = DSKitAsset.Image.Test.test1.image
     $0.contentMode = .scaleAspectFill
     $0.clipsToBounds = true
-    $0.layer.cornerRadius = 20
-    $0.layer.borderColor = DSKitAsset.Color.neutral700.color.cgColor
-    $0.layer.borderWidth = 10
+    $0.layer.cornerRadius = 20 * Metric.wRatio
   }
 
   lazy var nextBtn = CTAButton(btnTitle: "네, 좋아요", initialStatus: true)
+  
+  private enum Metric {
+    static let wRatio: CGFloat = UIScreen.main.bounds.width / 390.0
+    static let hRatio: CGFloat = UIScreen.main.bounds.height / 844
+  }
 
   override func makeUI() {
     addSubview(containerView)
@@ -90,12 +71,12 @@ final class SignUpCompleteView: TFBaseView {
     }
     gradientView.snp.makeConstraints {
       $0.center.equalToSuperview()
-      $0.size.equalTo(250)
+      $0.size.equalTo(184).multipliedBy(Metric.wRatio)
     }
 
     imageView.snp.makeConstraints {
       $0.center.equalToSuperview()
-      $0.size.equalTo(235)
+      $0.size.equalTo(160).multipliedBy(Metric.wRatio)
     }
 
     nextBtn.snp.makeConstraints {
@@ -105,10 +86,9 @@ final class SignUpCompleteView: TFBaseView {
     }
 
   }
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    conicGradient.frame = gradientView.bounds
+  
+  func startAnimation() {
+    gradientView.animate(frame: gradientView.bounds)
   }
 }
 #if canImport(SwiftUI) && DEBUG
@@ -125,4 +105,3 @@ struct SignUpCompleteViewPreview: PreviewProvider {
   }
 }
 #endif
-

--- a/Projects/Features/SignUp/Src/SignUpRoot/SignUpComplete/SignUpCompleteViewController.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/SignUpComplete/SignUpCompleteViewController.swift
@@ -26,6 +26,12 @@ final class SignUpCompleteViewController: TFBaseViewController {
   override func loadView() {
     self.view = mainView
   }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    
+    mainView.startAnimation()
+  }
 
   override func bindViewModel() {
     let input = ViewModel.Input(

--- a/Projects/Features/SignUp/Src/SubView/TFShimmerGradientView.swift
+++ b/Projects/Features/SignUp/Src/SubView/TFShimmerGradientView.swift
@@ -1,0 +1,110 @@
+//
+//  TFShimmerGradientView.swift
+//  SignUp
+//
+//  Created by kangho lee on 7/7/24.
+//
+
+import UIKit
+
+import DSKit
+
+final class TFShimmerGradientView: TFBaseView {
+  private var shapeLayer: CAShapeLayer?
+  private var conicGradient: CAGradientLayer?
+  private var timer: Timer?
+  enum Key {
+    static let conic = "conic"
+  }
+  private enum Color {
+      static var gradientColors = [
+        DSKitAsset.Color.primary500.color,
+        DSKitAsset.Color.primary500.color.withAlphaComponent(0.7),
+        DSKitAsset.Color.primary500.color.withAlphaComponent(0.4),
+        DSKitAsset.Color.thtOrange400.color.withAlphaComponent(0.5),
+        DSKitAsset.Color.thtOrange400.color.withAlphaComponent(0.7),
+        DSKitAsset.Color.thtOrange400.color,
+        DSKitAsset.Color.thtOrange400.color.withAlphaComponent(0.7),
+        DSKitAsset.Color.thtOrange400.color.withAlphaComponent(0.5),
+        DSKitAsset.Color.primary500.color.withAlphaComponent(0.4),
+        DSKitAsset.Color.primary500.color.withAlphaComponent(0.7),
+      ]
+    }
+  private enum Constants {
+    static let gradientLocation = [Int](0..<Color.gradientColors.count)
+        .map(Double.init)
+        .map { $0 / Double(Color.gradientColors.count) }
+        .map(NSNumber.init)
+    static let cornerRadius = 32.0
+      static let cornerWidth = 2.0
+    }
+  
+  deinit {
+    self.timer?.invalidate()
+    self.timer = nil
+  }
+
+  func animate(frame rect: CGRect) {
+    if self.shapeLayer == nil {
+      let shapeInstance = makeShapeLayer(rect: rect)
+      layer.mask = shapeInstance
+      self.shapeLayer = shapeInstance
+      
+      if self.conicGradient == nil {
+        let gradientInstance = makeConicGradient(rect: rect, layer: shapeInstance)
+        self.layer.addSublayer(gradientInstance)
+        self.conicGradient = gradientInstance
+      }
+    }
+    
+    self.timer?.invalidate()
+    self.timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true, block: {[weak self] _ in
+      guard let self else { return }
+      self.conicGradient?.removeAnimation(forKey: Key.conic)
+      let previous = Color.gradientColors.map(\.cgColor)
+      let last = Color.gradientColors.removeLast()
+      Color.gradientColors.insert(last, at: 0)
+      let lastColors = Color.gradientColors.map(\.cgColor)
+      
+      let colorsAnimation = CABasicAnimation(keyPath: "colors")
+      colorsAnimation.fromValue = previous
+      colorsAnimation.toValue = lastColors
+      colorsAnimation.repeatCount = 1
+      colorsAnimation.duration = 0.2
+      colorsAnimation.isRemovedOnCompletion = false
+      colorsAnimation.fillMode = .both
+      self.conicGradient?.add(colorsAnimation, forKey: Key.conic)
+    })
+  }
+  
+  private func makeConicGradient(rect: CGRect, layer mask: CALayer) -> CAGradientLayer {
+    let gradient = CAGradientLayer()
+    gradient.type = .conic
+    gradient.frame = rect
+    gradient.colors = Color.gradientColors.map(\.cgColor) as [Any]
+    gradient.backgroundColor = DSKitAsset.Color.thtOrange400.color.cgColor
+    gradient.locations = Constants.gradientLocation
+
+    // startPoint: 원의 중심, endPoint: 첫 번째 색상과 마지막 색상이 결합되는 지점
+    // (0,0)우측하단, (1,1)은 (0,0)에서 한바퀴 돌은 지점
+    gradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+    gradient.endPoint = CGPoint(x: 0.5, y: 1)
+    gradient.mask = mask
+    gradient.cornerRadius = Constants.cornerRadius
+    return gradient
+  }
+  
+  private func makeShapeLayer(rect: CGRect) -> CAShapeLayer {
+    let shape = CAShapeLayer()
+    shape.lineWidth = 5
+    shape.path = UIBezierPath(
+      roundedRect: rect.insetBy(dx: Constants.cornerWidth, dy: Constants.cornerWidth),
+      cornerRadius: Constants.cornerRadius).cgPath
+    
+    shape.cornerRadius = Constants.cornerRadius
+    shape.strokeColor = UIColor.white.cgColor
+    shape.fillColor = UIColor.clear.cgColor
+    return shape
+  }
+}
+

--- a/Projects/Modules/DesignSystem/Src/BaseView/TFBaseCollectionView.swift
+++ b/Projects/Modules/DesignSystem/Src/BaseView/TFBaseCollectionView.swift
@@ -7,35 +7,41 @@
 
 import UIKit
 
+import RxSwift
+
 open class TFBaseCollectionView: UICollectionView {
-  private let dimView: UIView = {
-    let view = UIView()
-    view.backgroundColor = DSKitAsset.Color.DimColor.default.color
-    return view
-  }()
+
+  private var dimView: UIView?
   
   public func showDimView(frame: CGRect = UIWindow.keyWindow?.frame ?? .zero) {
-    dimView.frame = frame
-    DispatchQueue.main.async { [weak self] in
-      guard let self = self else { return }
-      self.addSubview(self.dimView)
-      UIView.animate(withDuration: 0.0) {
-        self.dimView.backgroundColor = DSKitAsset.Color.DimColor.default.color
-      }
+
+    if self.dimView == nil {
+      let dimView = createDimView()
+      self.addSubviews(dimView)
+      self.dimView = dimView
+    }
+    dimView?.frame = frame
+
+    UIView.animate(withDuration: 0.3) {
+      self.dimView?.alpha = 1
     }
   }
   
   open func makeUI() {}
   
   public func hiddenDimView() {
-    DispatchQueue.main.async {
-      UIView.animate(withDuration: 0.0) { [weak self] in
-        guard let self = self else { return }
-        self.dimView.backgroundColor = DSKitAsset.Color.clear.color
-      } completion: { [weak self] _ in
-        guard let self = self else { return }
-        self.dimView.removeFromSuperview()
+    if let dimView {
+      DispatchQueue.main.async {
+        UIView.animate(withDuration: 0.3) {
+          dimView.alpha = 0
+        }
       }
     }
+  }
+
+  private func createDimView() -> UIView {
+    let view = UIView()
+    view.backgroundColor = DSKitAsset.Color.DimColor.default.color
+    return view
   }
 }

--- a/Projects/Modules/DesignSystem/Src/BaseView/TFBaseCollectionViewCell.swift
+++ b/Projects/Modules/DesignSystem/Src/BaseView/TFBaseCollectionViewCell.swift
@@ -21,8 +21,8 @@ open class TFBaseCollectionViewCell: UICollectionViewCell {
   }
 
   open override func prepareForReuse() {
-    self.disposeBag = DisposeBag()
     super.prepareForReuse()
+    self.disposeBag = DisposeBag()
   }
 
   open func makeUI() { }


### PR DESCRIPTION
## Motivation ⍰

- 폴링 피처에서 기능 추가 어려움

<br>

## Key Changes 🔑

### 구조 부분
- Timer를 VC ViewModel이 가지고 있게함 
  - timer 객체를 한군데서 관리하는 것이 제어하기 수월함.
  - 모든 셀이 timer를 가지고 있는 것보다 메모리 세이브
- ReactorKit 처럼 단방향 구현
- Cell viewModel 제거
- Cell binding 로직 변경 Action Forwarding 부분과 State Binding 부분으로 구분
- Cell Activate 시 Hashable Model identifier 사용 (기존 IndexPath)
- FallingUser - hash ID를 기존 UUID에서 userUUID로 변경함 따라서, Mock Data 넣을 때 안겹치도록 주의!
  - 변경한 이유: map 통해서 state 리스트 변경하는데 UUID로 하면 계속 id가 mutable상태가 되서 바뀜
- 제거 구현 snapshot에서 제거됨

### 파일 부분
- Timer 이름 TFTimer로 변경하여 파일 분리
- dotPosition 메소드 등 컴포넌트 의존 메소드들 컴포넌트 하위로 옮김

### UI 부분
- dimView, gradientLayer 등 remove하는 방식이 아니라 hidden형식을 변경함
  - 셀이 계속 재활용될 건데 매번 새로 만드는 것 보다 메모리, 퍼포먼스 상 유리함
  - 좋아요 그라디언트 겹쳐서 계속 생기는 문제 수정
- 카드 셀 페이지 컨트롤러 수정 
- 카드 높이 수정
<br>

## To Reviewers 🙏🏻

- (SwiftUI로 치면 Store)Reactor끼리 통신하는 경우도 사용하는 방법인지, 지양하는 방법인지 궁금합니다. 
예를 들어 유저 인터렉션 없이, 내부 state 변경으로 인해서 Cell UI를 띄어야하는 상황이 오면, 
A. 부모 Reactor가 Cell쪽으로 Action을 보내는지
아니면
B. 부모 Reactor가 Cell 거치지 않고, 바로 Cell Reactor에게 직접적으로 Action을 보내는지 궁금합니다.
[src](![Simulator Screen Recording - iPhone 15 - 2024-06-29 at 20 37 46](https://github.com/THT-Team/THT-iOS/assets/25360781/6dd5e44c-32d4-4060-9b0c-a7b1a64967aa))
<br>

## Linked Issue 🔗

- 
