### PR TITLE
Dev/kangho auth

### DIFF
--- a/Projects/App/Src/SceneDelegate+Register.swift
+++ b/Projects/App/Src/SceneDelegate+Register.swift
@@ -19,9 +19,8 @@ extension AppDelegate {
   }
 
   func registerDependencies() {
-    let tokenStore = UserDefaultTokenStore()
-    let tokenProvider = DefaultTokenProvider()
 
+    let authService = DefaultAuthService()
     let contactService = ContactService()
     let kakaoService = KakaoAPIService()
     let locationService = LocationService()
@@ -32,16 +31,14 @@ extension AppDelegate {
 
     container.register(
       interface: AuthUseCaseInterface.self,
-      implement: { AuthUseCase(authRepository: AuthRepository(tokenStore: tokenStore, tokenProvider: tokenProvider),
-                               tokenStore: tokenStore) })
+      implement: { AuthUseCase(authRepository: AuthRepository(authService: authService)) })
+
     container.register(
       interface: SignUpUseCaseInterface.self,
       implement: { SignUpUseCase(
-        repository: SignUpRepository(),
-        locationService: locationService,
-        kakaoAPIService: kakaoService,
-        contactService: contactService,
-        tokenStore: tokenStore)
+        repository: SignUpRepository(
+          authService: authService),
+        contactService: contactService)
       })
     
     container.register(

--- a/Projects/Data/Src/Base/DefaultProvider.swift
+++ b/Projects/Data/Src/Base/DefaultProvider.swift
@@ -1,0 +1,19 @@
+//
+//  DefaultProvider.swift
+//  Data
+//
+//  Created by Kanghos on 6/25/24.
+//
+
+import Foundation
+import Networks
+
+import Moya
+import Alamofire
+import AuthInterface
+
+extension ProviderProtocol {
+  static func makeStubProvider() -> MoyaProvider<Target> {
+    return consProvider(true)
+  }
+}

--- a/Projects/Data/Src/Model/Response/Kakao/KakaoCoordinate2dRes.swift
+++ b/Projects/Data/Src/Model/Response/Kakao/KakaoCoordinate2dRes.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SignUpInterface
+import AuthInterface
 
 struct KakaoCoordinateRes: Codable {
   let documents: [Document]

--- a/Projects/Data/Src/Model/Response/Kakao/KakaoSearchRes.swift
+++ b/Projects/Data/Src/Model/Response/Kakao/KakaoSearchRes.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import SignUpInterface
+import AuthInterface
 
 struct KakaoSearchRes: Codable {
   let documents: [Document]

--- a/Projects/Data/Src/Repository/Auth/TokenProvider.swift
+++ b/Projects/Data/Src/Repository/Auth/TokenProvider.swift
@@ -21,11 +21,15 @@ public final class DefaultTokenProvider: ProviderProtocol {
   public var provider: MoyaProvider<Target>
 
   public init() {
-    provider = MoyaProvider()
+    provider = Self.makeProvider()
   }
 }
 
 extension DefaultTokenProvider: TokenProvider {
+  public func signUp(_ signUpRequest: SignUpReq) -> Single<Token> {
+    request(type: Token.self, target: .signUp(signUpRequest))
+  }
+  
   public func refresh(token: AuthInterface.Token) -> RxSwift.Single<AuthInterface.Token> {
     request(type: Token.self, target: .refresh(token))
   }

--- a/Projects/Data/Src/Repository/Auth/TokenProviderTarget.swift
+++ b/Projects/Data/Src/Repository/Auth/TokenProviderTarget.swift
@@ -11,11 +11,13 @@ import Networks
 
 import Moya
 import AuthInterface
+import SignUpInterface
 
 public enum TokenProviderTarget {
   case login(phoneNumber: String, deviceKey: String)
   case loginSNS(request: UserSNSLoginRequest)
   case refresh(Token)
+  case signUp(SignUpReq)
 }
 
 extension TokenProviderTarget: BaseTargetType {
@@ -28,6 +30,8 @@ extension TokenProviderTarget: BaseTargetType {
       return "users/login/sns"
     case .refresh:
       return "users/login/refresh"
+    case .signUp:
+      return "users/join/signup"
     }
   }
 
@@ -47,6 +51,8 @@ extension TokenProviderTarget: BaseTargetType {
       return .requestParameters(parameters: snsDTO.toDictionary(), encoding: JSONEncoding.default)
     case let .refresh(token):
       return .requestParameters(parameters: token.toDictionary(), encoding: JSONEncoding.default)
+    case let .signUp(request):
+      return .requestJSONEncodable(request)
     }
   }
 }

--- a/Projects/Data/Src/Repository/Local/UserDefaultTokenStore.swift
+++ b/Projects/Data/Src/Repository/Local/UserDefaultTokenStore.swift
@@ -23,8 +23,8 @@ public final class UserDefaultTokenStore: TokenStore {
     try? UserDefaults.standard.setCodableObject(token, forKey: Key.token)
   }
 
-  public func getToken() throws -> Token {
-    try UserDefaults.standard.getCodableObject(forKey: Key.token, as: AuthInterface.Token.self)
+  public func getToken() -> Token? {
+    try? UserDefaults.standard.getCodableObject(forKey: Key.token, as: AuthInterface.Token.self)
   }
 
   public func clearToken() {

--- a/Projects/Data/Src/Repository/MyPage/MyPageRepository.swift
+++ b/Projects/Data/Src/Repository/MyPage/MyPageRepository.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import MyPageInterface
 import SignUpInterface
+import AuthInterface
 
 import Networks
 
@@ -21,7 +22,7 @@ public final class MyPageRepository: ProviderProtocol {
   public var provider: MoyaProvider<Target>
 
   public init() {
-    self.provider = Self.makeStubProvider()
+    self.provider = MoyaProvider()
   }
   public init(isStub: Bool, sampleStatusCode: Int, customEndpointClosure: ((Target) -> Moya.Endpoint)?) {
     self.provider = MyPageRepository.consProvider(isStub, sampleStatusCode, customEndpointClosure)
@@ -34,17 +35,12 @@ extension MyPageRepository: MyPageRepositoryInterface {
     .just(1)
   }
   
-  public func updateUserContacts(contacts: [SignUpInterface.ContactType]) -> RxSwift.Single<Int> {
-    request(type: UserFriendContactRes.self, target: .updateUserContacts(contacts))
-      .map { $0.count }
+  public func updateUserContacts(contacts: [ContactType]) -> RxSwift.Single<Int> {
+    .just(1)
   }
 
   public func fetchUser() -> Single<User> {
     request(type: UserDetailRes.self, target: .user)
       .map { $0.toDomain() }
-  }
-
-  public func updateAlarmSetting(_ settings: [String: Bool]) -> Completable {
-    requestWithNoContent(target: .updateAlarmSetting(settings))
   }
 }

--- a/Projects/Data/Src/Repository/SignUp/SignUpRepository.swift
+++ b/Projects/Data/Src/Repository/SignUp/SignUpRepository.swift
@@ -15,20 +15,15 @@ import RxSwift
 import RxMoya
 import Moya
 
-import Core
-
 public final class SignUpRepository: ProviderProtocol {
 
   public typealias Target = SignUpTarget
   public var provider: MoyaProvider<Target>
+  private let authService: AuthServiceType
 
-  public init(isStub: Bool, sampleStatusCode: Int, customEndpointClosure: ((SignUpTarget) -> Moya.Endpoint)?) {
-    self.provider = Self.consProvider(isStub, sampleStatusCode, customEndpointClosure)
-    TFLogger.dataLogger.log("SignUpRepository init")
-  }
-
-  public convenience init() {
-    self.init(isStub: false, sampleStatusCode: 200, customEndpointClosure: nil)
+  public init(authService: AuthServiceType) {
+    self.authService = authService
+    self.provider = Self.makeProvider(session: authService.createSession())
   }
 }
 
@@ -37,11 +32,12 @@ extension SignUpRepository: SignUpRepositoryInterface {
     .just(["test.jpg", "test2.jpg"])
   }
   
-  public func signUp(_ signUpRequest: SignUpInterface.SignUpReq) -> RxSwift.Single<AuthInterface.Token> {
-    request(type: Token.self, target: .signUp(signUpReq: signUpRequest))
+  public func signUp(_ signUpRequest: SignUpReq) -> Single<Void> {
+    authService.signUp(signUpRequest)
+      .map { _ in }
   }
   
-  public func certificate(phoneNumber: String) -> RxSwift.Single<Int> {
+  public func certificate(phoneNumber: String) -> Single<Int> {
     Single.just(PhoneValidationResponse(phoneNumber: "01012345678", authNumber: 123456))
       .map { $0.authNumber }
 

--- a/Projects/Data/Src/Repository/SignUp/SignUpTarget.swift
+++ b/Projects/Data/Src/Repository/SignUp/SignUpTarget.swift
@@ -19,7 +19,6 @@ public enum SignUpTarget {
   case idealTypes
   case interests
   case block(contacts: UserFriendContactReq)
-  case signUp(signUpReq: SignUpReq)
   case agreement
 }
 
@@ -39,8 +38,6 @@ extension SignUpTarget: BaseTargetType {
       return "interests"
     case .block:
       return "user/friend-contact-list"
-    case .signUp:
-      return "users/join/signup"
     case .agreement:
       return "users/join/agreements/main-category"
     }
@@ -49,8 +46,6 @@ extension SignUpTarget: BaseTargetType {
   public var method: Moya.Method {
     switch self {
     case .block:
-      return .post
-    case .signUp:
       return .post
     default: return .get
     }
@@ -61,8 +56,6 @@ extension SignUpTarget: BaseTargetType {
     switch self {
     case let .block(contacts):
       return .requestParameters(parameters: contacts.toDictionary(), encoding: JSONEncoding.default)
-    case let .signUp(dto):
-      return .requestParameters(parameters: dto.toDictionary(), encoding: JSONEncoding.default)
     default:
       return .requestPlain
     }

--- a/Projects/Data/Src/Service/AuthService.swift
+++ b/Projects/Data/Src/Service/AuthService.swift
@@ -1,0 +1,116 @@
+//
+//  AuthService.swift
+//  Data
+//
+//  Created by Kanghos on 6/26/24.
+//
+
+import Foundation
+
+import RxSwift
+
+import AuthInterface
+import SignUpInterface
+
+import Moya
+import Alamofire
+
+public protocol SessionFactoryType {
+  func createSession() -> Session
+}
+
+public protocol AuthServiceType: SessionFactoryType {
+  var cachedToken: Token? { get set }
+
+  func clearToken()
+  func refreshToken(completion: @escaping (Result<Token, Error>) -> Void)
+  func refresh() -> Single<Token>
+  func login(phoneNumber: String, deviceKey: String) -> Single<Token>
+  func loginSNS(_ userSNSLoginRequest: UserSNSLoginRequest) -> Single<Token>
+  func signUp(_ signUpRequest: SignUpReq) -> Single<Token>
+}
+
+public final class DefaultAuthService: AuthServiceType {
+  private let tokenStore: TokenStore
+  private let tokenProvider: TokenProvider
+  public var cachedToken: Token?
+  private lazy var authenticator: AuthenticationInterceptor<OAuthAuthenticator> = {
+    createInterceptor()
+  }()
+
+  public init(tokenStore: TokenStore = UserDefaultTokenStore(), tokenProvider: TokenProvider = DefaultTokenProvider()) {
+    self.tokenStore = tokenStore
+    self.tokenProvider = tokenProvider
+  }
+
+  public func clearToken() {
+    tokenStore.clearToken()
+  }
+
+  public func createSession() -> Session {
+    return Session(interceptor: authenticator)
+  }
+
+  public func signUp(_ signUpRequest: SignUpReq) -> Single<Token> {
+    tokenProvider.signUp(signUpRequest)
+      .flatMap { [unowned self] token in
+        self.tokenStore.saveToken(token: token)
+        return .just(token)
+      }
+  }
+
+  public func refreshToken(completion: @escaping (Result<Token, Error>) -> Void) {
+    guard let token = tokenStore.getToken() else {
+      completion(.failure(AuthError.tokenNotFound))
+      return
+    }
+    tokenProvider.refreshToken(token: token) { [weak self] result in
+      switch result {
+      case .success(let refreshed):
+        self?.tokenStore.saveToken(token: refreshed)
+        self?.cachedToken = refreshed
+        completion(.success(refreshed))
+      case .failure(let error):
+        completion(.failure(error))
+      }
+    }
+  }
+
+  public func refresh() -> Single<Token> {
+    guard let token = tokenStore.getToken() else {
+      return .error(AuthError.tokenNotFound)
+    }
+    return tokenProvider.refresh(token: token)
+      .flatMap { [unowned self] token in
+        self.tokenStore.saveToken(token: token)
+        self.cachedToken = token
+        return .just(token)
+      }
+  }
+
+  public func login(phoneNumber: String, deviceKey: String) -> Single<Token> {
+    tokenProvider.login(phoneNumber: phoneNumber, deviceKey: deviceKey)
+      .flatMap { [unowned self] token in
+        self.tokenStore.saveToken(token: token)
+        self.cachedToken = token
+        return .just(token)
+      }
+  }
+
+  public func loginSNS(_ userSNSLoginRequest: UserSNSLoginRequest) -> Single<Token> {
+    tokenProvider.loginSNS(userSNSLoginRequest)
+      .flatMap { [unowned self] token in
+        self.tokenStore.saveToken(token: token)
+        self.cachedToken = token
+        return .just(token)
+      }
+  }
+
+  private func createInterceptor() -> AuthenticationInterceptor<OAuthAuthenticator> {
+    let credential = tokenStore.getToken()?.toAuthOCredential() ?? OAuthCredential(accessToken: "", accessTokenExpiresIn: Date().timeIntervalSince1970)
+
+    let authenticator = OAuthAuthenticator(authService: self)
+    let intercepter = AuthenticationInterceptor(authenticator: authenticator, credential: credential)
+    return intercepter
+  }
+}

--- a/Projects/Data/Src/Service/ContactService.swift
+++ b/Projects/Data/Src/Service/ContactService.swift
@@ -8,6 +8,7 @@
 import Foundation
 import RxSwift
 import SignUpInterface
+import AuthInterface
 import Contacts
 
 enum ContactError: Error {

--- a/Projects/Data/Src/Service/KakaoAPIService.swift
+++ b/Projects/Data/Src/Service/KakaoAPIService.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import SignUpInterface
+import AuthInterface
 import Networks
 
 import Moya

--- a/Projects/Data/Src/Service/LocationService.swift
+++ b/Projects/Data/Src/Service/LocationService.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 import CoreLocation
+
 import SignUpInterface
+import AuthInterface
 
 import RxSwift
 

--- a/Projects/Features/Auth/Demo/Src/AppDelegate+Register.swift
+++ b/Projects/Features/Auth/Demo/Src/AppDelegate+Register.swift
@@ -21,18 +21,14 @@ extension AppDelegate {
   }
 
   func registerDependencies() {
-    let tokenStore = UserDefaultTokenStore()
-    let tokenProvider = DefaultTokenProvider()
+    let authService = DefaultAuthService()
 
     container.register(
       interface: SignUpUseCaseInterface.self,
       implement: {
         SignUpUseCase(
-          repository: SignUpRepository(),
-          locationService: LocationService(),
-          kakaoAPIService: KakaoAPIService(),
-          contactService: ContactService(),
-          tokenStore: tokenStore
+          repository: SignUpRepository(authService: authService),
+          contactService: ContactService()
         )
       }
     )
@@ -40,10 +36,7 @@ extension AppDelegate {
     container.register(
       interface: AuthUseCaseInterface.self,
       implement: {
-        AuthUseCase(
-          authRepository: AuthRepository(tokenStore: tokenStore, tokenProvider: tokenProvider),
-          tokenStore: tokenStore
-        )
+        AuthUseCase(authRepository: AuthRepository(authService: authService))
       })
 
     container.register(

--- a/Projects/Features/Auth/Interface/Src/DTO/Request/LocationRequest.swift
+++ b/Projects/Features/Auth/Interface/Src/DTO/Request/LocationRequest.swift
@@ -1,0 +1,26 @@
+//
+//  LocationRequest.swift
+//  AuthInterface
+//
+//  Created by Kanghos on 6/26/24.
+//
+
+import Foundation
+
+// MARK: - LocationRequest
+public struct LocationReq: Codable {
+  public let address: String
+  public let regionCode: Int
+  public let lat, lon: Double
+
+  public init(
+    address: String,
+    regionCode: Int,
+    lat: Double, lon: Double
+  ) {
+    self.address = address
+    self.regionCode = regionCode
+    self.lat = lat
+    self.lon = lon
+  }
+}

--- a/Projects/Features/Auth/Interface/Src/DTO/Request/UserSignUpRequest.swift
+++ b/Projects/Features/Auth/Interface/Src/DTO/Request/UserSignUpRequest.swift
@@ -1,0 +1,55 @@
+//
+//  UserSignUpRequest.swift
+//  AuthInterface
+//
+//  Created by Kanghos on 6/26/24.
+//
+
+import Foundation
+
+public struct SignUpReq: Encodable {
+  public let phoneNumber, username, email, birthDay: String
+  public let gender, preferGender: String
+  public let introduction, deviceKey: String
+  public let agreement: [String: Bool]
+  public let locationRequest: LocationReq
+  public var photoList: [String]
+  public let interestList, idealTypeList: [Int]
+  public let snsType: String
+  public let snsUniqueID: String
+  public let tall: Int
+  public let smoking: String
+  public let drinking: String
+  public let religion: String
+  public let contacts: [ContactType]
+
+  enum CodingKeys: String, CodingKey {
+    case phoneNumber, username, email, birthDay, gender, preferGender, introduction, deviceKey, agreement, locationRequest, photoList, interestList, idealTypeList, snsType
+    case snsUniqueID = "snsUniqueId"
+    case tall, smoking, drinking, religion
+    case contacts
+  }
+
+  public init(phoneNumber: String, username: String, email: String, birthDay: String, gender: String, preferGender: String, introduction: String, deviceKey: String, agreement: [String: Bool], locationRequest: LocationReq, photoList: [String], interestList: [Int], idealTypeList: [Int], snsType: String, snsUniqueID: String, tall: Int, smoking: String, drinking: String, religion: String, contacts: [ContactType]) {
+    self.phoneNumber = phoneNumber
+    self.username = username
+    self.email = email
+    self.birthDay = birthDay
+    self.gender = gender
+    self.preferGender = preferGender
+    self.introduction = introduction
+    self.deviceKey = deviceKey
+    self.agreement = agreement
+    self.locationRequest = locationRequest
+    self.photoList = photoList
+    self.interestList = interestList
+    self.idealTypeList = idealTypeList
+    self.snsType = snsType
+    self.snsUniqueID = snsUniqueID
+    self.tall = tall
+    self.smoking = smoking
+    self.drinking = drinking
+    self.religion = religion
+    self.contacts = contacts
+  }
+}

--- a/Projects/Features/Auth/Interface/Src/Model/AuthError.swift
+++ b/Projects/Features/Auth/Interface/Src/Model/AuthError.swift
@@ -9,4 +9,14 @@ import Foundation
 
 public enum AuthError: Error {
   case invalidToken
+  case tokenNotFound
+
+  var message: String {
+    switch self {
+    case .invalidToken:
+      return "올바르지 않은 토큰입니다."
+    case .tokenNotFound:
+      return "토큰을 찾을 수 없습니다."
+    }
+  }
 }

--- a/Projects/Features/Auth/Interface/Src/Model/ContactType.swift
+++ b/Projects/Features/Auth/Interface/Src/Model/ContactType.swift
@@ -1,0 +1,18 @@
+//
+//  ContactType.swift
+//  AuthInterface
+//
+//  Created by Kanghos on 6/26/24.
+//
+
+import Foundation
+
+public struct ContactType: Codable {
+  public let name: String
+  public let phoneNumber: String
+
+  public init(name: String, phoneNumber: String) {
+    self.name = name
+    self.phoneNumber = phoneNumber
+  }
+}

--- a/Projects/Features/Auth/Interface/Src/RepositoryInterface/AuthRepositoryInterface.swift
+++ b/Projects/Features/Auth/Interface/Src/RepositoryInterface/AuthRepositoryInterface.swift
@@ -14,6 +14,6 @@ public protocol AuthRepositoryInterface {
   func checkUserExist(phoneNumber: String) -> Single<UserSignUpInfoRes>
   func login(phoneNumber: String, deviceKey: String) -> Single<Token>
   func loginSNS(_ userSNSLoginRequest: UserSNSLoginRequest) -> Single<Token>
-  func refresh(_ token: Token, completion: @escaping (Result<Token, Error>) -> Void)
-  func refresh(_ token: Token) -> Single<Token>
+  func refresh(completion: @escaping (Result<Token, Error>) -> Void)
+  func refresh() -> Single<Token>
 }

--- a/Projects/Features/Auth/Interface/Src/RepositoryInterface/TokenProvider.swift
+++ b/Projects/Features/Auth/Interface/Src/RepositoryInterface/TokenProvider.swift
@@ -13,4 +13,5 @@ public protocol TokenProvider {
   func refresh(token: Token) -> Single<Token>
   func login(phoneNumber: String, deviceKey: String) -> Single<Token>
   func loginSNS(_ userSNSLoginRequest: UserSNSLoginRequest) -> Single<Token>
+  func signUp(_ signUpRequest: SignUpReq) -> Single<Token>
 }

--- a/Projects/Features/Auth/Interface/Src/RepositoryInterface/TokenStore.swift
+++ b/Projects/Features/Auth/Interface/Src/RepositoryInterface/TokenStore.swift
@@ -11,6 +11,6 @@ import RxSwift
 public protocol TokenStore {
   var cachedToken: Token? { get set }
   func saveToken(token: Token)
-  func getToken() throws -> Token
+  func getToken() -> Token?
   func clearToken()
 }

--- a/Projects/Features/Auth/Src/Launcher/TFAuthLauncherViewController.swift
+++ b/Projects/Features/Auth/Src/Launcher/TFAuthLauncherViewController.swift
@@ -16,6 +16,9 @@ public final class TFAuthLauncherViewController: TFLaunchViewController {
     super.init(nibName: nil, bundle: nil)
   }
 
+  deinit {
+    TFLogger.cycle(name: self)
+  }
 
   public required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
@@ -28,6 +31,12 @@ public final class TFAuthLauncherViewController: TFLaunchViewController {
 
     output.state
       .drive()
+      .disposed(by: disposeBag)
+
+    output.toast
+      .emit(with: self, onNext: { owner, message in
+        owner.view.makeToast(message)
+      })
       .disposed(by: disposeBag)
   }
 }

--- a/Projects/Features/Falling/Demo/Src/AppDelegate.swift
+++ b/Projects/Features/Falling/Demo/Src/AppDelegate.swift
@@ -12,6 +12,8 @@ import Data
 
 import FallingInterface
 import Falling
+import AuthInterface
+import Auth
 //import FirebaseCore
 
 @main
@@ -20,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
     registerDependencies()
-    
+
     return true
   }
 
@@ -38,6 +40,14 @@ extension AppDelegate {
   }
 
   func registerDependencies() {
+    let authService = DefaultAuthService()
+
+    container.register(
+      interface: AuthUseCaseInterface.self,
+      implement: {
+        AuthUseCase(
+          authRepository: AuthRepository(authService: authService))})
+
     container.register(
       interface: FallingUseCaseInterface.self,
       implement: {
@@ -49,6 +59,8 @@ extension AppDelegate {
         )
       }
     )
+
+
   }
 }
 

--- a/Projects/Features/Falling/Src/Home/FallingHomeView.swift
+++ b/Projects/Features/Falling/Src/Home/FallingHomeView.swift
@@ -78,6 +78,10 @@ extension NSCollectionLayoutSection {
     )
     section.interGroupSpacing = 14
     section.boundarySupplementaryItems = [sectionFooter]
+    
+    section.visibleItemsInvalidationHandler = { item, offset, environment in
+      
+    }
     return section
   }
   

--- a/Projects/Features/Falling/Src/Subviews/CardCircleTimerView.swift
+++ b/Projects/Features/Falling/Src/Subviews/CardCircleTimerView.swift
@@ -116,4 +116,44 @@ final class CardCircleTimerView: TFBaseView {
     
     layer.addSublayer(gradientLayer)
   }
+  
+  func bind(_ timeState: TimeState) {
+    trackLayer.strokeColor = timeState.trackLayerStrokeColor.color.cgColor
+    strokeLayer.strokeColor = timeState.timerTintColor.color.cgColor
+    dotLayer.strokeColor = timeState.timerTintColor.color.cgColor
+    dotLayer.fillColor = timeState.timerTintColor.color.cgColor
+    timerLabel.textColor = timeState.timerTintColor.color
+    
+    
+    dotLayer.isHidden = timeState.isDotHidden
+    
+    timerLabel.text = timeState.getText
+    
+    // 소수점 3번 째자리까지 표시하면 오차가 발생해서 2번 째자리까지만 표시
+    let strokeEnd = round(timeState.getProgress * 100) / 100
+    
+    dotLayer.position = dotPosition(progress: strokeEnd, rect: bounds, lineWidth: strokeLayer.lineWidth)
+    
+    strokeLayer.strokeEnd = strokeEnd
+  }
+  
+  private func dotPosition(progress: CGFloat, rect: CGRect, lineWidth: CGFloat) -> CGPoint {
+    let radius = CGFloat(rect.height / 2 - lineWidth / 2)
+      
+    // 3 / 2 pi(정점 각도) -> - 1 / 2 pi(정점)
+    var angle = 2 * CGFloat.pi * progress - CGFloat.pi / 2 + CGFloat.pi / 10 // 두 원의 중점과 원점이 이루는 각도를 18도로 가정
+    if angle <= -CGFloat.pi / 2 || CGFloat.pi * 1.5 <= angle  {
+      angle = -CGFloat.pi / 2 // 정점 각도
+    }
+    
+    let dotX = radius * cos(angle)
+    let dotY = radius * sin(angle)
+    
+    let point = CGPoint(x: dotX, y: dotY)
+    
+    return CGPoint(
+      x: rect.midX + point.x,
+      y: rect.midY + point.y
+    )
+  }
 }

--- a/Projects/Features/MyPage/Demo/Src/AppDelegate+Register.swift
+++ b/Projects/Features/MyPage/Demo/Src/AppDelegate+Register.swift
@@ -22,8 +22,7 @@ extension AppDelegate {
   }
 
   func registerDependencies() {
-    let tokenStore = UserDefaultTokenStore()
-    let tokenProvider = DefaultTokenProvider()
+    let authService = DefaultAuthService()
 
     let locationService = LocationService()
     let kakaoService = KakaoAPIService()
@@ -33,11 +32,8 @@ extension AppDelegate {
       interface: SignUpUseCaseInterface.self,
       implement: {
         SignUpUseCase(
-          repository: SignUpRepository(),
-          locationService: locationService,
-          kakaoAPIService: kakaoService,
-          contactService: contactService,
-          tokenStore: tokenStore
+          repository: SignUpRepository(authService: authService),
+          contactService: contactService
         )
       }
     )

--- a/Projects/Features/MyPage/Interface/Src/RepositoryInterface/MyPageRepositoryInterface.swift
+++ b/Projects/Features/MyPage/Interface/Src/RepositoryInterface/MyPageRepositoryInterface.swift
@@ -10,6 +10,7 @@ import RxSwift
 import RxCocoa
 
 import SignUpInterface
+import AuthInterface
 
 import RxSwift
 import RxCocoa

--- a/Projects/Features/SignUp/Demo/Src/AppDelegate+Register.swift
+++ b/Projects/Features/SignUp/Demo/Src/AppDelegate+Register.swift
@@ -20,18 +20,25 @@ extension AppDelegate {
   }
 
   func registerDependencies() {
+    let authService = DefaultAuthService()
+    let locationService = LocationService()
+    let kakoService = KakaoAPIService()
 
     container.register(
       interface: SignUpUseCaseInterface.self,
       implement: {
         SignUpUseCase(
-          repository: SignUpRepository(),
-          locationService: LocationService(),
-          kakaoAPIService: KakaoAPIService(),
+          repository: SignUpRepository(authService: authService),
           contactService: ContactService()
         )
       }
     )
+
+    container.register(
+      interface: LocationUseCaseInterface.self,
+      implement: {
+        LocationUseCase(locationService: locationService,
+                        kakaoAPIService: kakoService)})
 
     container.register(
       interface: UserInfoUseCaseInterface.self,

--- a/Projects/Features/SignUp/Interface/Src/DTO/Request/LocationReq.swift
+++ b/Projects/Features/SignUp/Interface/Src/DTO/Request/LocationReq.swift
@@ -7,20 +7,3 @@
 
 import Foundation
 
-// MARK: - LocationRequest
-public struct LocationReq: Codable {
-  public let address: String
-  public let regionCode: Int
-  public let lat, lon: Double
-
-  public init(
-    address: String,
-    regionCode: Int,
-    lat: Double, lon: Double
-  ) {
-    self.address = address
-    self.regionCode = regionCode
-    self.lat = lat
-    self.lon = lon
-  }
-}

--- a/Projects/Features/SignUp/Interface/Src/DTO/Request/SignUpReq.swift
+++ b/Projects/Features/SignUp/Interface/Src/DTO/Request/SignUpReq.swift
@@ -8,53 +8,6 @@
 import Foundation
 import AuthInterface
 
-public struct SignUpReq: Encodable {
-  public let phoneNumber, username, email, birthDay: String
-  public let gender, preferGender: String
-  public let introduction, deviceKey: String
-  public let agreement: [String: Bool]
-  public let locationRequest: LocationReq
-  public var photoList: [String]
-  public let interestList, idealTypeList: [Int]
-  public let snsType: String
-  public let snsUniqueID: String
-  public let tall: Int
-  public let smoking: String
-  public let drinking: String
-  public let religion: String
-  public let contacts: [ContactType]
-
-  enum CodingKeys: String, CodingKey {
-    case phoneNumber, username, email, birthDay, gender, preferGender, introduction, deviceKey, agreement, locationRequest, photoList, interestList, idealTypeList, snsType
-    case snsUniqueID = "snsUniqueId"
-    case tall, smoking, drinking, religion
-    case contacts
-  }
-
-  public init(phoneNumber: String, username: String, email: String, birthDay: String, gender: String, preferGender: String, introduction: String, deviceKey: String, agreement: [String: Bool], locationRequest: LocationReq, photoList: [String], interestList: [Int], idealTypeList: [Int], snsType: String, snsUniqueID: String, tall: Int, smoking: String, drinking: String, religion: String, contacts: [ContactType]) {
-    self.phoneNumber = phoneNumber
-    self.username = username
-    self.email = email
-    self.birthDay = birthDay
-    self.gender = gender
-    self.preferGender = preferGender
-    self.introduction = introduction
-    self.deviceKey = deviceKey
-    self.agreement = agreement
-    self.locationRequest = locationRequest
-    self.photoList = photoList
-    self.interestList = interestList
-    self.idealTypeList = idealTypeList
-    self.snsType = snsType
-    self.snsUniqueID = snsUniqueID
-    self.tall = tall
-    self.smoking = smoking
-    self.drinking = drinking
-    self.religion = religion
-    self.contacts = contacts
-  }
-}
-
 extension UserInfo {
   public func toRequest(contacts: [ContactType]) -> SignUpReq? {
     guard 

--- a/Projects/Features/SignUp/Interface/Src/DTO/Request/UserFriendContactReq.swift
+++ b/Projects/Features/SignUp/Interface/Src/DTO/Request/UserFriendContactReq.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import AuthInterface
+
 public struct UserFriendContactReq: Codable {
   public let contacts: [ContactType]
 

--- a/Projects/Features/SignUp/Interface/Src/Model/ContactType.swift
+++ b/Projects/Features/SignUp/Interface/Src/Model/ContactType.swift
@@ -6,13 +6,3 @@
 //
 
 import Foundation
-
-public struct ContactType: Codable {
-  public let name: String
-  public let phoneNumber: String
-
-  public init(name: String, phoneNumber: String) {
-    self.name = name
-    self.phoneNumber = phoneNumber
-  }
-}

--- a/Projects/Features/SignUp/Interface/Src/Model/UserInfo.swift
+++ b/Projects/Features/SignUp/Interface/Src/Model/UserInfo.swift
@@ -8,6 +8,8 @@
 import Foundation
 import Domain
 
+import AuthInterface
+
 public struct UserInfo: Codable {
   public var phoneNumber: String
   public var name: String?

--- a/Projects/Features/SignUp/Interface/Src/RepositoryInterface/SignUpRepositoryInterface.swift
+++ b/Projects/Features/SignUp/Interface/Src/RepositoryInterface/SignUpRepositoryInterface.swift
@@ -14,7 +14,7 @@ public protocol SignUpRepositoryInterface {
   func checkNickname(nickname: String) -> Single<Bool>
   func idealTypes() -> Single<[EmojiType]>
   func interests() -> Single<[EmojiType]>
-  func signUp(_ signUpRequest: SignUpReq) -> Single<Token>
+  func signUp(_ signUpRequest: SignUpReq) -> Single<Void>
   func uploadImage(data: [Data]) -> Single<[String]>
   func fetchAgreements() -> Single<Agreement>
 }

--- a/Projects/Features/SignUp/Interface/Src/UseCase/ContactServiceType.swift
+++ b/Projects/Features/SignUp/Interface/Src/UseCase/ContactServiceType.swift
@@ -9,6 +9,8 @@ import Foundation
 
 import RxSwift
 
+import AuthInterface
+
 public protocol ContactServiceType {
   func fetchContact() -> Single<[ContactType]>
 }

--- a/Projects/Features/SignUp/Interface/Src/UseCase/KakaoAPIServiceType.swift
+++ b/Projects/Features/SignUp/Interface/Src/UseCase/KakaoAPIServiceType.swift
@@ -9,6 +9,8 @@ import Foundation
 
 import RxSwift
 
+import AuthInterface
+
 public protocol KakaoAPIServiceType {
   func fetchLocationByCoordinate2d(longitude: Double, latitude: Double) -> Single<LocationReq?>
   func fetchLocationByAddress(address: String) -> Single<LocationReq?>

--- a/Projects/Features/SignUp/Interface/Src/UseCase/LocationServiceType.swift
+++ b/Projects/Features/SignUp/Interface/Src/UseCase/LocationServiceType.swift
@@ -8,6 +8,8 @@
 import Foundation
 import RxSwift
 
+import AuthInterface
+
 public protocol LocationServiceType {
   var publisher: PublishSubject<LocationReq> { get }
   func handleAuthorization(granted: @escaping (Bool) -> Void)

--- a/Projects/Features/SignUp/Interface/Src/UseCase/LocationUseCaseInterface.swift
+++ b/Projects/Features/SignUp/Interface/Src/UseCase/LocationUseCaseInterface.swift
@@ -9,6 +9,8 @@ import Foundation
 
 import RxSwift
 
+import AuthInterface
+
 public protocol LocationUseCaseInterface {
   func fetchLocation() -> Single<LocationReq>
   func fetchLocation(address: String) -> Single<LocationReq>

--- a/Projects/Features/SignUp/Interface/Src/UseCase/SignUpUseCaseInterface.swift
+++ b/Projects/Features/SignUp/Interface/Src/UseCase/SignUpUseCaseInterface.swift
@@ -10,6 +10,8 @@ import Foundation
 import RxSwift
 import Domain
 
+import AuthInterface
+
 public protocol SignUpUseCaseInterface {
   func checkNickname(nickname: String) -> Single<Bool>
   func idealTypes() -> Single<[Domain.EmojiType]>

--- a/Projects/Features/SignUp/Src/Coordinator/SignUpStore.swift
+++ b/Projects/Features/SignUp/Src/Coordinator/SignUpStore.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SignUpInterface
+import AuthInterface
 import Core
 
 protocol Signing {

--- a/Projects/Features/SignUp/Src/SignUpRoot/Location/LocationInputViewModel.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/Location/LocationInputViewModel.swift
@@ -12,6 +12,7 @@ import Core
 import RxSwift
 import RxCocoa
 import SignUpInterface
+import AuthInterface
 
 final class LocationInputViewModel: ViewModelType {
   private var disposeBag = DisposeBag()

--- a/Projects/Features/SignUp/Src/SignUpRoot/SignUpComplete/SignUpCompleteViewModel.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/SignUpComplete/SignUpCompleteViewModel.swift
@@ -13,6 +13,7 @@ import RxSwift
 import RxCocoa
 
 import SignUpInterface
+import AuthInterface
 
 final class SignUpCompleteViewModel: ViewModelType {
   private let useCase: SignUpUseCaseInterface

--- a/Projects/Features/SignUp/Src/SignUpRoot/UserContact/UserContactViewModel.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/UserContact/UserContactViewModel.swift
@@ -13,6 +13,7 @@ import RxSwift
 import RxCocoa
 
 import SignUpInterface
+import AuthInterface
 
 final class UserContactViewModel: ViewModelType {
   private let useCase: SignUpUseCaseInterface

--- a/Projects/Features/SignUp/Src/UseCase/LocationUseCase.swift
+++ b/Projects/Features/SignUp/Src/UseCase/LocationUseCase.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SignUpInterface
+import AuthInterface
 
 import RxSwift
 

--- a/Projects/Features/SignUp/Src/UseCase/SignUpUseCase.swift
+++ b/Projects/Features/SignUp/Src/UseCase/SignUpUseCase.swift
@@ -14,14 +14,12 @@ import Domain
 public final class SignUpUseCase: SignUpUseCaseInterface {
 
   private let repository: SignUpRepositoryInterface
-  private let tokenStore: TokenStore
 
   private let contactService: ContactServiceType
 
-  public init(repository: SignUpRepositoryInterface, locationService: LocationServiceType, kakaoAPIService: KakaoAPIServiceType, contactService: ContactServiceType, tokenStore: TokenStore) {
+  public init(repository: SignUpRepositoryInterface, contactService: ContactServiceType) {
     self.repository = repository
     self.contactService = contactService
-    self.tokenStore = tokenStore
   }
 
   public func checkNickname(nickname: String) -> Single<Bool> {
@@ -46,10 +44,6 @@ public final class SignUpUseCase: SignUpUseCaseInterface {
 
   public func signUp(request: SignUpReq) -> Single<Void> {
     return repository.signUp(request)
-      .flatMap { [weak self] token in
-        self?.tokenStore.saveToken(token: token)
-        return .just(())
-      }
   }
 
   public func uploadImage(data: [Data]) -> Single<[String]> {

--- a/Projects/Modules/DesignSystem/Src/BaseView/TFBaseCollectionView.swift
+++ b/Projects/Modules/DesignSystem/Src/BaseView/TFBaseCollectionView.swift
@@ -25,6 +25,8 @@ open class TFBaseCollectionView: UICollectionView {
     }
   }
   
+  open func makeUI() {}
+  
   public func hiddenDimView() {
     DispatchQueue.main.async {
       UIView.animate(withDuration: 0.0) { [weak self] in


### PR DESCRIPTION
## Motivation ⍰

- 회원가입도 토큰 발급 서비스라서 auth로 책임 변경

<br>

## Key Changes 🔑

- 회원가입관련 모델, 서비스 auth로 책임 변경 및 파일 위치 변경
- token store와 token provider 역할 합친 auth service facade만듦
- 1 authenticator + multi session으로 구현, 앱 라이프사이클 내에서 authenticator 1이고, provider마다 다른 세션 부여
  -  provider마다 timeout등 세션 config 다양하게 적용 가능, but 이 정도 규모 앱에서 그럴 필요가 있는지 의문임
<br>

## To Reviewers 🙏🏻

- 1 Authenticator + 1 Session vs 1 Authenticator + Multi Session 의견
- alamofire authenticator 뜯어보니, 내부적으로 serial 큐 이용해서 작동합니다.
<br>

## Linked Issue 🔗

- 
