### PR TITLE
Refactor: File, Persistent Repository

### DIFF
--- a/Projects/App/Src/SceneDelegate+Register.swift
+++ b/Projects/App/Src/SceneDelegate+Register.swift
@@ -24,10 +24,11 @@ extension AppDelegate {
     let contactService = ContactService()
     let kakaoService = KakaoAPIService()
     let locationService = LocationService()
+    let fileRepository = FileRepository()
 
     container.register(
       interface: UserInfoUseCaseInterface.self,
-      implement: { UserInfoUseCase(repository: UserDefaultUserInfoRepository()) })
+      implement: { UserInfoUseCase(fileRepository: fileRepository) })
 
     container.register(
       interface: AuthUseCaseInterface.self,

--- a/Projects/Core/Src/BaseRepository/FileRepositoryInterface.swift
+++ b/Projects/Core/Src/BaseRepository/FileRepositoryInterface.swift
@@ -1,0 +1,36 @@
+//
+//  FileRepository.swift
+//  Core
+//
+//  Created by Kanghos on 7/3/24.
+//
+
+import Foundation
+
+public protocol FileRepositoryInterface {
+  typealias FileModel = (fileName: String, data: Data)
+  func fetch(fileName: String) -> Data?
+  func delete(path: String)
+  @discardableResult
+  func save(fileName: String, data: Data) -> String?
+}
+
+public extension FileRepositoryInterface {
+  func fetch(fileNames: [String]) -> [Data] {
+    return fileNames.reduce([]) {
+      guard let data = fetch(fileName: $1) else {
+        return $0
+      }
+      return  $0 + [data]
+    }
+  }
+
+  func save(_ fileModels: [FileModel]) -> [String] {
+    fileModels.reduce([]) {
+      guard let name = save(fileName: $1.fileName, data: $1.data) else {
+        return $0
+      }
+      return $0 + [name]
+    }
+  }
+}

--- a/Projects/Core/Src/BaseRepository/PersistentRepositoryInterface.swift
+++ b/Projects/Core/Src/BaseRepository/PersistentRepositoryInterface.swift
@@ -1,0 +1,35 @@
+//
+//  LocalRepositoryInterface.swift
+//  Core
+//
+//  Created by Kanghos on 7/3/24.
+//
+
+import Foundation
+
+public enum PersistentKey: String {
+  case marketAgreement = "marketing_agreement"
+  case alarmSetting = "alarm_setting"
+  case accessToken = "access_token"
+  case userInfo = "user_info"
+  case phoneNumber = "phone_number"
+  case pendingUser = "pending_user"
+  case snsType = "sns_type"
+  case deviceKey = "device_key"
+  case snsUUID = "sns_uuid"
+}
+
+public protocol KeyValueStorageInterface {
+  func remove(key: PersistentKey)
+  func save<T>(_ value: T, key: PersistentKey)
+  func fetch<T>(for key: PersistentKey, type: T.Type) -> T?
+}
+
+public protocol ModelStorageInterface {
+  func removeModel<T>(key: PersistentKey, model: T.Type)
+  @discardableResult
+  func saveModel<T: Encodable>(_ model: T, key: PersistentKey) -> Bool
+  func fetchModel<T: Decodable>(for key: PersistentKey, type: T.Type) -> T?
+}
+
+public protocol PersistentRepositoryInterface: KeyValueStorageInterface & ModelStorageInterface { }

--- a/Projects/Core/Src/BaseRepository/UserDefaultRepository.swift
+++ b/Projects/Core/Src/BaseRepository/UserDefaultRepository.swift
@@ -1,0 +1,50 @@
+//
+//  UserDefaultPersistentRepository.swift
+//  Core
+//
+//  Created by Kanghos on 7/9/24.
+//
+
+import Foundation
+
+// TODO: Singletone 으로 변경
+public final class UserDefaultRepository: PersistentRepositoryInterface {
+  private let userDefault: UserDefaults
+  private init() {
+    self.userDefault = UserDefaults.standard
+  }
+
+  public static let shared = UserDefaultRepository()
+
+  public func remove(key: PersistentKey) {
+    userDefault.removeObject(forKey: key.rawValue)
+  }
+
+  public func save<T>(_ value: T, key: PersistentKey) {
+    userDefault.set(value, forKey: key.rawValue)
+    userDefault.synchronize()
+  }
+
+  public func fetch<T>(for key: PersistentKey, type: T.Type) -> T? {
+    userDefault.object(forKey: key.rawValue) as? T
+  }
+
+  public func removeModel<T>(key: PersistentKey, model: T.Type) {
+    userDefault.removeObject(forKey: key.rawValue)
+  }
+
+  @discardableResult
+  public func saveModel<T>(_ model: T, key: PersistentKey) -> Bool where T : Encodable {
+    guard let _ = try? userDefault.setCodableObject(model, forKey: key.rawValue) else {
+      return false
+    }
+    return true
+  }
+
+  public func fetchModel<T>(for key: PersistentKey, type: T.Type) -> T? where T : Decodable {
+    guard let model = try? userDefault.getCodableObject(forKey: key.rawValue, as: type) else {
+      return nil
+    }
+    return model
+  }
+}

--- a/Projects/Data/Src/Repository/Local/FileRepository.swift
+++ b/Projects/Data/Src/Repository/Local/FileRepository.swift
@@ -1,0 +1,61 @@
+//
+//  FileRepository.swift
+//  Data
+//
+//  Created by Kanghos on 7/3/24.
+//
+
+import Foundation
+
+import Core
+
+public final class FileRepository: FileRepositoryInterface {
+
+  private let fileManager: FileManager
+  private let userDomain: URL
+
+  public init() {
+    self.fileManager = FileManager.default
+    self.userDomain = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+  }
+  public func save(fileName: String, data: Data) -> String? {
+    let url = userDomain.appending(component: fileName)
+    let directory = url.deletingLastPathComponent()
+
+    do {
+      if !fileManager.fileExists(atPath: directory.path()) {
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+      }
+      try data.write(to: url)
+      return url.lastPathComponent
+    }  catch {
+        TFLogger.dataLogger.error("\(error.localizedDescription)")
+        return nil
+      }
+//    do {
+//      try data.write(to: url)
+//      return url.lastPathComponent
+//    } catch {
+//      TFLogger.dataLogger.error("Save Failed!")
+//      return nil
+//    }
+  }
+
+  public func fetch(fileName: String) -> Data? {
+    let url = userDomain.appending(path: fileName, directoryHint: .notDirectory)
+    do {
+      return try Data(contentsOf: url)
+    } catch {
+      TFLogger.dataLogger.error("\(error.localizedDescription)")
+      return nil
+    }
+  }
+  
+  public func delete(path: String) {
+    do{
+      try fileManager.removeItem(atPath: path)
+    } catch {
+      TFLogger.dataLogger.error("\(error.localizedDescription)")
+    }
+  }
+}

--- a/Projects/Features/Auth/Interface/Src/AuthUseCaseInterface.swift
+++ b/Projects/Features/Auth/Interface/Src/AuthUseCaseInterface.swift
@@ -15,4 +15,6 @@ public protocol AuthUseCaseInterface {
   func login(phoneNumber: String, deviceKey: String) -> Single<Void>
   func loginSNS(_ request: UserSNSLoginRequest) -> Single<Void>
   func refresh() -> Single<Void>
+  func saveSNSType(type snsTYpe: SNSType, snsUUID: String?)
+  func saveDeviceKey(_ deviceKey: String)
 }

--- a/Projects/Features/Auth/Src/AuthRoot/Root/AuthRootViewModel.swift
+++ b/Projects/Features/Auth/Src/AuthRoot/Root/AuthRootViewModel.swift
@@ -29,6 +29,7 @@ final class AuthRootViewModel: ViewModelType {
   func transform(input: Input) -> Output {
     input.buttonTap
       .drive(with: self, onNext: { owner, sns in
+        UserDefaultRepository.shared.saveModel(sns, key: .snsType)
         owner.delegate?.invoke(.tologinType(sns))
       })
       .disposed(by: disposeBag)

--- a/Projects/Features/Auth/Src/UseCase/AuthUseCase.swift
+++ b/Projects/Features/Auth/Src/UseCase/AuthUseCase.swift
@@ -44,4 +44,13 @@ public final class AuthUseCase: AuthUseCaseInterface {
     return repository.refresh()
       .map { _ in }
   }
+
+  public func saveSNSType(type snsTYpe: SNSType, snsUUID: String?) {
+    UserDefaultRepository.shared.save(snsTYpe.rawValue, key: .snsType)
+    UserDefaultRepository.shared.save(snsUUID, key: .snsUUID)
+  }
+
+  public func saveDeviceKey(_ deviceKey: String) {
+    UserDefaultRepository.shared.save(deviceKey, key: .deviceKey)
+  }
 }

--- a/Projects/Features/MyPage/Interface/Src/Model/AlarmSetting.swift
+++ b/Projects/Features/MyPage/Interface/Src/Model/AlarmSetting.swift
@@ -6,6 +6,23 @@
 //
 
 import Foundation
+import SignUpInterface
+
+import Core
+
+public struct AlarmSettingFactory {
+  public static func createDefaultAlarmSetting() -> AlarmSetting {
+    var defaultAlarmSetting = AlarmSetting.defaultSetting
+    let timestamp = Date()
+    let markettingAlarm = UserDefaultRepository.shared.fetchModel(for: .marketAgreement, type: MarketingInfoAgreement.self) ?? .init(isAgree: false, timeStamp: timestamp.toDateString())
+
+    defaultAlarmSetting.settings.merge(["marketingAlarm": markettingAlarm.isAgree]) { last, new in
+      new
+    }
+    defaultAlarmSetting.lastUpdated = timestamp
+    return defaultAlarmSetting
+  }
+}
 
 public struct AlarmSetting: Codable {
   public var settings: [String: Bool]

--- a/Projects/Features/MyPage/Src/Setting/AlarmSetting/AlarmSettingViewModel.swift
+++ b/Projects/Features/MyPage/Src/Setting/AlarmSetting/AlarmSettingViewModel.swift
@@ -25,7 +25,6 @@ final class AlarmSettingViewModel: ViewModelType {
 
   func transform(input: Input) -> Output {
     let toast = PublishRelay<String>()
-    let updateMarketingSection = PublishRelay<AlarmSection>()
     let initialState = myPageUseCase.fetchAlarmSetting()
     let state = BehaviorRelay<[String: Bool]>(value: initialState.settings)
     let marketAlarmDidChange = PublishRelay<Bool>()
@@ -54,7 +53,7 @@ final class AlarmSettingViewModel: ViewModelType {
       .asDriver()
       .skip(1)
       .debounce(.milliseconds(500))
-      .scan(initialState.settings) { last, new in // TODO: initialState를 어떻게 가져가야할지도 고민
+      .scan(initialState.settings) { last, new in
         let key = AlarmModel.marketingAlarm.rawValue
         if last[key] != new[key] {
           let isAgree = new[key] ?? false

--- a/Projects/Features/SignUp/Interface/Src/DTO/Request/SignUpReq.swift
+++ b/Projects/Features/SignUp/Interface/Src/DTO/Request/SignUpReq.swift
@@ -17,12 +17,12 @@ extension UserInfo {
       let preferGender = self.preferGender?.rawValue,
       let birthday = self.birthday,
       let introduction = self.introduction,
-      let agreement = self.userAgreements,
       let location = self.address,
       let tall = self.tall,
       let drinking = self.drinking?.rawValue,
       let smoking = self.smoking?.rawValue,
-      let religion = self.religion?.rawValue
+      let religion = self.religion?.rawValue,
+      self.userAgreements.isEmpty == false
 
     else { return nil }
 
@@ -35,7 +35,7 @@ extension UserInfo {
       preferGender: preferGender,
       introduction: introduction,
       deviceKey: "device-key",
-      agreement: agreement,
+      agreement: self.userAgreements,
       locationRequest: location,
       photoList: photos,
       interestList: interestsList,

--- a/Projects/Features/SignUp/Interface/Src/Model/MarketingInfoAgreement.swift
+++ b/Projects/Features/SignUp/Interface/Src/Model/MarketingInfoAgreement.swift
@@ -1,0 +1,18 @@
+//
+//  MarketingInfoAgreement.swift
+//  SignUp
+//
+//  Created by Kanghos on 7/3/24.
+//
+
+import Foundation
+
+public struct MarketingInfoAgreement: Codable {
+  public var isAgree: Bool
+  public var timeStamp: String
+
+  public init(isAgree: Bool, timeStamp: String) {
+    self.isAgree = isAgree
+    self.timeStamp = timeStamp
+  }
+}

--- a/Projects/Features/SignUp/Interface/Src/Model/UserInfo.swift
+++ b/Projects/Features/SignUp/Interface/Src/Model/UserInfo.swift
@@ -27,9 +27,9 @@ public struct UserInfo: Codable {
   public var idealTypeList: [Int]
   public var interestsList: [Int]
   public var photos: [String]
-  public var userAgreements: [String: Bool]?
+  public var userAgreements: [String: Bool]
 
-  public init(phoneNumber: String, name: String? = nil, userUUID: String? = nil, birthday: String? = nil, introduction: String? = nil, address: LocationReq? = nil, email: String? = nil, gender: Gender? = nil, preferGender: Gender? = nil, tall: Int? = nil, smoking: Frequency? = nil, drinking: Frequency? = nil, religion: Religion? = nil, idealTypeList: [Int] = [], interestsList: [Int] = [], photos: [String] = [], userAgreements: [String: Bool]? = nil) {
+  public init(phoneNumber: String, name: String? = nil, userUUID: String? = nil, birthday: String? = nil, introduction: String? = nil, address: LocationReq? = nil, email: String? = nil, gender: Gender? = nil, preferGender: Gender? = nil, tall: Int? = nil, smoking: Frequency? = nil, drinking: Frequency? = nil, religion: Religion? = nil, idealTypeList: [Int] = [], interestsList: [Int] = [], photos: [String] = [], userAgreements: [String: Bool] = [:]) {
     self.phoneNumber = phoneNumber
     self.name = name
     self.userUUID = userUUID

--- a/Projects/Features/SignUp/Interface/Src/UseCase/UserInfoUseCaseInterface.swift
+++ b/Projects/Features/SignUp/Interface/Src/UseCase/UserInfoUseCaseInterface.swift
@@ -13,6 +13,7 @@ public protocol UserInfoUseCaseInterface {
   func fetchPhoneNumber() -> Single<String>
   func fetchUserInfo() -> Single<UserInfo>
   func updateUserInfo(userInfo: UserInfo)
+  func updateMarketingAgreement(isAgree: Bool)
   func deleteUserInfo()
   func fetchUserPhotos(key: String, fileNames: [String]) -> Single<[Data]>
   func saveUserPhotos(key: String, datas: [Data]) -> Single<[String]>

--- a/Projects/Features/SignUp/Src/SignUpRoot/Photo/PhotoInputViewModel.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/Photo/PhotoInputViewModel.swift
@@ -71,6 +71,7 @@ final class PhotoInputViewModel: ViewModelType {
     userinfo.map { (key: $0.phoneNumber,fileNames: $0.photos) }
       .asObservable()
       .withUnretained(self)
+      .observe(on: ConcurrentDispatchQueueScheduler.init(qos: .userInitiated))
       .flatMapLatest { owner, components in
         owner.userInfoUseCase.fetchUserPhotos(key: components.key, fileNames: components.fileNames)
           .catchAndReturn([])

--- a/Projects/Features/SignUp/Src/SignUpRoot/Policy/PolicyAgreementViewController.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/Policy/PolicyAgreementViewController.swift
@@ -35,15 +35,12 @@ final class PolicyAgreementViewController: TFBaseViewController {
     let cellAction = PublishRelay<(IndexPath, PolicyAgreementViewModel.CellAction)>()
 
     customView.tableView.rx.itemSelected.asDriver()
-      .do(onNext: { [weak self] IndexPath in
-//        self?.customView.tableView.deselectRow(at: IndexPath, animated: true)
-      })
       .drive(onNext: { indexPath in
         cellAction.accept((indexPath, .Agree))
       }).disposed(by: disposeBag)
 
     let input = PolicyAgreementViewModel.Input(
-      viewDidAppear: rx.viewDidAppear.asDriver().map { _ in },
+      viewWillAppear: rx.viewWillAppear.asDriver().map { _ in },
       agreeAllBtn: customView.selectAllBtn.rx.tap.asDriver(),
       cellTap: cellAction.asDriverOnErrorJustEmpty(),
       nextBtn: customView.nextBtn.rx.tap.asDriver()

--- a/Projects/Features/SignUp/Src/SignUpRoot/PreferGenderPick/PreferGenderPickerViewController.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/PreferGenderPick/PreferGenderPickerViewController.swift
@@ -38,6 +38,7 @@ final class PreferGenderPickerViewController: TFBaseViewController {
       .compactMap { GenderMapper.toGender($0) }
 
     let input = PreferGenderPickerViewModel.Input(
+      viewWillAppear: rx.viewWillAppear.mapToVoid().asDriverOnErrorJustEmpty(),
       genderTap: genderTap,
       nextBtnTap: self.mainView.nextBtn.rx.tap.asDriver()
     )

--- a/Projects/Features/SignUp/Src/SignUpRoot/PreferGenderPick/PreferGenderPickerViewModel.swift
+++ b/Projects/Features/SignUp/Src/SignUpRoot/PreferGenderPick/PreferGenderPickerViewModel.swift
@@ -18,6 +18,7 @@ final class PreferGenderPickerViewModel: ViewModelType {
   private let userInfoUseCase: UserInfoUseCaseInterface
 
   struct Input {
+    let viewWillAppear: Driver<Void>
     var genderTap: Driver<Gender>
     var nextBtnTap: Driver<Void>
   }
@@ -39,7 +40,7 @@ final class PreferGenderPickerViewModel: ViewModelType {
 
   func transform(input: Input) -> Output {
 
-    let userinfo = Driver.just(())
+    let userinfo = input.viewWillAppear
       .asObservable()
       .withUnretained(self)
       .flatMap { owner, _ in


### PR DESCRIPTION
## Motivation ⍰

- 기존 UserInfoRepository 잘못 설계해서 재사용성이 낮음

<br>

## Key Changes 🔑
Core 모듈 추가
- Generic하게 설계
- 기존 UserDefault에서 단순 유저 정보는 키체인으로, 모델은 Realm 고려하여 protocol 만듦.
- Add: File, Persistent Repository
- Feat: 마케팅 정보 Local 저장, SNSType Local 저장
- Refactor: Image Load Main Thread에서 Concurrent Thread로 바꿈.
- Fix: 이전 상태 userInfo가 덮어씌워지는 문제 해결
  - trigger를 viewDIdLoad(just)에서 viewWillAppear로 변경

<br>

## To Reviewers 🙏🏻
- [ ] Core말고 레파지토리 인터페이스를 소유할 만한 좋은 곳이 있는지?
- [ ] Storage 키 관리를 어디서 해야하는지? 현재는 UseCase에 Key 선언
```swift
// Core
public protocol KeyValueStorageInterface {
  func remove(key: String)
  func save<T>(_ value: T, key: String)
  func fetch<T>(for key: String, type: T.Type) -> T?
}

public protocol ModelStorageInterface {
  func removeModel<T>(key: String, model: T.Type)
  @discardableResult
  func saveModel<T: Encodable>(_ model: T, key: String) -> Bool
  func fetchModel<T: Decodable>(for key: String, type: T.Type) -> T?
}

public protocol PersistentRepositoryInterface: KeyValueStorageInterface & ModelStorageInterface { }
```

<br>

## Linked Issue 🔗

- #102 
